### PR TITLE
[ECS][PHPStan] Add ThrowExceptionMessageRule

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,9 @@
         </include>
     </coverage>
     <testsuites>
+        <testsuite name="PHPStan">
+            <directory>tests/PHPStan</directory>
+        </testsuite>
         <testsuite name="Rector">
             <directory>tests/Rector</directory>
         </testsuite>

--- a/src/PHPStan/ThrowExceptionMessageRule.php
+++ b/src/PHPStan/ThrowExceptionMessageRule.php
@@ -7,6 +7,7 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Throw_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
@@ -14,24 +15,26 @@ use PHPStan\ShouldNotHappenException;
 
 final class ThrowExceptionMessageRule implements Rule
 {
+    private const DEFAULT_VALID_PREFIXES = ['exceptions.'];
+
     public const ERROR_MESSAGE = 'Exception message must be either a variable or a translation message, started with one of [%s]';
 
     /**
-     * @var string
+     * @var string|null
      */
     private $exceptionInterface;
 
     /**
-     * @var string[]
+     * @var string[]|null
      */
     private $validPrefixes;
 
     public function __construct(
         ?string $exceptionInterface = null,
-        array $validPrefixes = ['exceptions.']
+        ?array $validPrefixes = null
     ) {
-        $this->validPrefixes = $validPrefixes;
         $this->exceptionInterface = $exceptionInterface;
+        $this->validPrefixes = $validPrefixes ?? self::DEFAULT_VALID_PREFIXES;
     }
 
 
@@ -62,7 +65,7 @@ final class ThrowExceptionMessageRule implements Rule
         }
 
         $stringNode = $expr->args[0]->value;
-        if (!$stringNode instanceof Node\Scalar\String_) {
+        if (!$stringNode instanceof String_) {
             return [];
         }
         $errors = [];

--- a/src/PHPStan/ThrowExceptionMessageRule.php
+++ b/src/PHPStan/ThrowExceptionMessageRule.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\PHPStan;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Throw_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+final class ThrowExceptionMessageRule implements Rule
+{
+    public const ERROR_MESSAGE = 'Exception message must be either a variable or a translation message, started with one of [%s]';
+
+    /**
+     * @var string
+     */
+    private $exceptionInterface;
+
+    /**
+     * @var string[]
+     */
+    private $validPrefixes;
+
+    public function __construct(
+        ?string $exceptionInterface = null,
+        array $validPrefixes = ['exceptions.']
+    ) {
+        $this->validPrefixes = $validPrefixes;
+        $this->exceptionInterface = $exceptionInterface;
+    }
+
+
+    public function getNodeType(): string
+    {
+        return Throw_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof Throw_) {
+            throw new ShouldNotHappenException();
+        }
+        $expr = $node->expr;
+
+        if (!$expr instanceof New_ && !$expr instanceof StaticCall) {
+            return [];
+        }
+
+        if ($this->exceptionInterface !== null
+            && !\is_a($expr->class->toString(), $this->exceptionInterface, true)
+        ) {
+            return [];
+        }
+
+        if (count($expr->args) === 0) {
+            return [];
+        }
+
+        $stringNode = $expr->args[0]->value;
+        if (!$stringNode instanceof Node\Scalar\String_) {
+            return [];
+        }
+        $errors = [];
+        if (!$this->startsWithValidPrefix($stringNode->value)) {
+            $errors[] = \sprintf(
+                self::ERROR_MESSAGE,
+                \implode(', ', $this->validPrefixes)
+            );
+        }
+
+        return $errors;
+    }
+
+    private function startsWithValidPrefix(string $message): bool
+    {
+        foreach ($this->validPrefixes as $validPrefix) {
+            if (Strings::startsWith($message, $validPrefix) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/anotherExceptionType.php.inc
+++ b/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/anotherExceptionType.php.inc
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+use App\Services\Workflows\Exceptions\InvalidArgumentException;
+
+throw new InvalidArgumentException('Some message');

--- a/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/multilineException.php.inc
+++ b/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/multilineException.php.inc
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+use App\Services\Workflows\Exceptions\InvalidArgumentException;
+
+throw new InvalidArgumentException(
+    'exceptions.some_message'
+);

--- a/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/noExceptionMessage.php.inc
+++ b/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/noExceptionMessage.php.inc
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+throw new NotFoundHttpException();

--- a/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/throwVariable.php.inc
+++ b/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/throwVariable.php.inc
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+
+$exception = new Exception('Some exception message');
+throw $exception;

--- a/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/validPrefix.php.inc
+++ b/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/validPrefix.php.inc
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+
+throw new LogicException('exceptions.some_message');

--- a/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/variableMessage.php.inc
+++ b/tests/PHPStan/ThrowExceptionMessageRule/Fixture/correct/variableMessage.php.inc
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+
+$message = 'Some exception message';
+throw new RuntimeException($message);

--- a/tests/PHPStan/ThrowExceptionMessageRule/Fixture/wrong/hardcodedMessage.php.inc
+++ b/tests/PHPStan/ThrowExceptionMessageRule/Fixture/wrong/hardcodedMessage.php.inc
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+
+throw new InvalidArgumentException('Incorrect message');
+

--- a/tests/PHPStan/ThrowExceptionMessageRule/ThrowExceptionMessageRuleTest.php
+++ b/tests/PHPStan/ThrowExceptionMessageRule/ThrowExceptionMessageRuleTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PHPStan\ThrowExceptionMessageRule;
+
+use EonX\EasyQuality\PHPStan\ThrowExceptionMessageRule;
+use Iterator;
+use PHPStan\Rules\Rule;
+use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
+
+/**
+ * @covers \EonX\EasyQuality\PHPStan\ThrowExceptionMessageRule
+ *
+ * @internal
+ */
+final class ThrowExceptionMessageRuleTest extends AbstractServiceAwareRuleTestCase
+{
+    public function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(
+            ThrowExceptionMessageRule::class,
+            __DIR__ . '/config/configured_rule.neon'
+        );
+    }
+
+    public function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/correct/anotherExceptionType.php.inc', []];
+
+        yield [__DIR__ . '/Fixture/correct/multilineException.php.inc', []];
+
+        yield [__DIR__ . '/Fixture/correct/noExceptionMessage.php.inc', []];
+
+        yield [__DIR__ . '/Fixture/correct/throwVariable.php.inc', []];
+
+        yield [__DIR__ . '/Fixture/correct/validPrefix.php.inc', []];
+
+        yield [__DIR__ . '/Fixture/correct/variableMessage.php.inc', []];
+
+        $errorMessage = \sprintf(ThrowExceptionMessageRule::ERROR_MESSAGE, 'exceptions.');
+        yield [__DIR__ . '/Fixture/wrong/hardcodedMessage.php.inc', [[$errorMessage, 4]]];
+    }
+
+    /**
+     * @dataProvider provideData()
+     *
+     * @param array<string|int> $expectedErrorMessagesWithLines
+     */
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+}

--- a/tests/PHPStan/ThrowExceptionMessageRule/config/configured_rule.neon
+++ b/tests/PHPStan/ThrowExceptionMessageRule/config/configured_rule.neon
@@ -1,0 +1,8 @@
+services:
+    -
+        class: EonX\EasyQuality\PHPStan\ThrowExceptionMessageRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            exceptionInterface: \Exception
+            validPrefixes:
+                - exceptions.


### PR DESCRIPTION
Add `\EonX\EasyQuality\PHPStan\ThrowExceptionMessageRule` similar to `\EonX\EasyQuality\Sniffs\Exceptions\ThrowExceptionMessageSniff` which can also check that exception implements some interface (for example `EonX\EasyErrorHandler\Interfaces\Exceptions\TranslatableExceptionInterface`).