### PR TITLE
feature/php-doc-comment-rector-fix

### DIFF
--- a/src/Rector/PhpDocCommentRector.php
+++ b/src/Rector/PhpDocCommentRector.php
@@ -85,7 +85,7 @@ PHP
 
     public function refactor(Node $node): ?Node
     {
-        if ($node->hasAttribute(AttributeKey::PHP_DOC_INFO)) {
+        if (!$node instanceof Node\AttributeGroup && $node->hasAttribute(AttributeKey::PHP_DOC_INFO)) {
             $this->phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
             $this->checkPhpDoc();
         }

--- a/src/Rector/PhpDocCommentRector.php
+++ b/src/Rector/PhpDocCommentRector.php
@@ -6,6 +6,7 @@ namespace EonX\EasyQuality\Rector;
 
 use Nette\Utils\Strings;
 use PhpParser\Node;
+use PhpParser\Node\AttributeGroup;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
@@ -85,7 +86,7 @@ PHP
 
     public function refactor(Node $node): ?Node
     {
-        if (!$node instanceof Node\AttributeGroup && $node->hasAttribute(AttributeKey::PHP_DOC_INFO)) {
+        if ($node instanceof AttributeGroup === false && $node->hasAttribute(AttributeKey::PHP_DOC_INFO)) {
             $this->phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
             $this->checkPhpDoc();
         }

--- a/tests/Rector/PhpDocCommentRector/Fixture/ClassHasCorrectPhpDoc.php.inc
+++ b/tests/Rector/PhpDocCommentRector/Fixture/ClassHasCorrectPhpDoc.php.inc
@@ -53,6 +53,8 @@ class ClassHasCorrectPhpDoc
      *
      * @var string
      */
+    #[\Some\Attribute]
+    #[\Some\Another\Attribute]
     private $test;
 
     /**


### PR DESCRIPTION
Currently this rector process children of the attribute group which actually doc-block is. 
At this point, we already have doc-block processed, so It leads to reprocessing doc-block against that in turn leads to duplicating doc-block at the end of processing.

To avoid this duplication I propose to skip the `AttributeGroup` node.