### PR TITLE
feature/add-covers-annotation-rector-fix

### DIFF
--- a/src/Rector/AddCoversAnnotationRector.php
+++ b/src/Rector/AddCoversAnnotationRector.php
@@ -125,7 +125,7 @@ PHP
      */
     private function resolveCoveredClassName(string $className): ?string
     {
-        $className = (string)\preg_replace('/Test$/', '', \str_replace($this->replaceArray, '', $className));
+        $className = (string)\preg_replace('/Test$/', '', \str_replace($this->replaceArray ?? [], '', $className));
 
         if (\class_exists($className)) {
             return $className;


### PR DESCRIPTION
In PHP 8 first argument of `\str_replace()` should be `string|array`.
But chances are that `$this->replaceArray` going to be not initialized in case the `configure` method wasn't called.
