### PR TITLE
[EasyQuality] Use DocCommentSpacingSniff from slevomat repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "phpstan/phpdoc-parser": "^1.2",
         "phpstan/phpstan": "^1.4",
         "rector/rector": "^0.12",
-        "slevomat/coding-standard": "^7.0",
+        "slevomat/coding-standard": "^7.1",
         "symplify/easy-coding-standard": "^10.0",
         "symplify/phpstan-extensions": "^10.0",
         "symplify/phpstan-rules": "^10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,34 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fdf49487f8ca6ba5403a7f973ea712c4",
+    "content-hash": "12c61ac7e077cc0261a0a35dbd2a3c80",
     "packages": [
         {
             "name": "composer/pcre",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.3",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "symfony/phpunit-bridge": "^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -59,7 +59,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/1.0.1"
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
             },
             "funding": [
                 {
@@ -75,31 +75,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-21T20:24:37+00:00"
+            "time": "2022-02-25T20:21:48+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.4",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "0c1a3925ec58a4ec98e992b9c7d171e9e184be0a"
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/0c1a3925ec58a4ec98e992b9c7d171e9e184be0a",
-                "reference": "0c1a3925ec58a4ec98e992b9c7d171e9e184be0a",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
                 "shasum": ""
             },
             "require": {
-                "composer/pcre": "^1",
-                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0"
+                "symfony/phpunit-bridge": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -125,7 +125,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.4"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
             },
             "funding": [
                 {
@@ -141,31 +141,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-04T17:06:45+00:00"
+            "time": "2022-02-25T21:32:43+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "sensiolabs/security-checker": "^4.1.0"
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -186,6 +186,10 @@
                     "email": "franck.nijhof@dealerdirect.com",
                     "homepage": "http://www.frenck.nl",
                     "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -197,6 +201,7 @@
                 "codesniffer",
                 "composer",
                 "installer",
+                "phpcbf",
                 "phpcs",
                 "plugin",
                 "qa",
@@ -211,7 +216,7 @@
                 "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "time": "2020-12-07T18:04:37+00:00"
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "jangregor/phpstan-prophecy",
@@ -280,16 +285,16 @@
         },
         {
             "name": "nette/neon",
-            "version": "v3.3.2",
+            "version": "v3.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/neon.git",
-                "reference": "54b287d8c2cdbe577b02e28ca1713e275b05ece2"
+                "reference": "22e384da162fab42961d48eb06c06d3ad0c11b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/neon/zipball/54b287d8c2cdbe577b02e28ca1713e275b05ece2",
-                "reference": "54b287d8c2cdbe577b02e28ca1713e275b05ece2",
+                "url": "https://api.github.com/repos/nette/neon/zipball/22e384da162fab42961d48eb06c06d3ad0c11b95",
+                "reference": "22e384da162fab42961d48eb06c06d3ad0c11b95",
                 "shasum": ""
             },
             "require": {
@@ -342,9 +347,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/neon/issues",
-                "source": "https://github.com/nette/neon/tree/v3.3.2"
+                "source": "https://github.com/nette/neon/tree/v3.3.3"
             },
-            "time": "2021-11-25T15:57:41+00:00"
+            "time": "2022-03-10T02:04:26+00:00"
         },
         {
             "name": "nette/utils",
@@ -546,22 +551,22 @@
         },
         {
             "name": "phpmd/phpmd",
-            "version": "2.11.1",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "08b60a2eb7e14c23f46ff8865b510ae08b75d0fd"
+                "reference": "c0b678ba71902f539c27c14332aa0ddcf14388ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/08b60a2eb7e14c23f46ff8865b510ae08b75d0fd",
-                "reference": "08b60a2eb7e14c23f46ff8865b510ae08b75d0fd",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/c0b678ba71902f539c27c14332aa0ddcf14388ec",
+                "reference": "c0b678ba71902f539c27c14332aa0ddcf14388ec",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.0 || ^2.0",
+                "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
                 "ext-xml": "*",
-                "pdepend/pdepend": "^2.10.2",
+                "pdepend/pdepend": "^2.10.3",
                 "php": ">=5.3.9"
             },
             "require-dev": {
@@ -617,7 +622,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/phpmd",
                 "issues": "https://github.com/phpmd/phpmd/issues",
-                "source": "https://github.com/phpmd/phpmd/tree/2.11.1"
+                "source": "https://github.com/phpmd/phpmd/tree/2.12.0"
             },
             "funding": [
                 {
@@ -625,39 +630,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-17T11:25:43+00:00"
+            "time": "2022-03-24T13:33:01+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.2.0",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e"
+                "reference": "4cb3021a4e10ffe3d5f94a4c34cf4b3f6de2fa3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
-                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/4cb3021a4e10ffe3d5f94a4c34cf4b3f6de2fa3d",
+                "reference": "4cb3021a4e10ffe3d5f94a4c34cf4b3f6de2fa3d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan": "^1.5",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PHPStan\\PhpDocParser\\": [
@@ -672,26 +672,26 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.4.2"
             },
-            "time": "2021-09-16T20:46:02+00:00"
+            "time": "2022-03-30T13:33:37+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.4.2",
+            "version": "1.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1dd8f3e40bf7aa30031a75c65cece99220a161b8"
+                "reference": "bbf68cae24f6dc023c607ea0f87da55dd9d55c2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1dd8f3e40bf7aa30031a75c65cece99220a161b8",
-                "reference": "1dd8f3e40bf7aa30031a75c65cece99220a161b8",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/bbf68cae24f6dc023c607ea0f87da55dd9d55c2b",
+                "reference": "bbf68cae24f6dc023c607ea0f87da55dd9d55c2b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.2|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -701,11 +701,6 @@
                 "phpstan.phar"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "bootstrap.php"
@@ -718,7 +713,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.4.2"
+                "source": "https://github.com/phpstan/phpstan/tree/1.5.4"
             },
             "funding": [
                 {
@@ -738,26 +733,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-18T16:09:11+00:00"
+            "time": "2022-04-03T12:39:00+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -784,9 +784,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/log",
@@ -840,21 +840,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "0.12.15",
+            "version": "0.12.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "e923bcd0d675dc4d8746da0554089b484044d0b5"
+                "reference": "cfa8d3e236a6e1a41d69712a84d434dfdf70e560"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e923bcd0d675dc4d8746da0554089b484044d0b5",
-                "reference": "e923bcd0d675dc4d8746da0554089b484044d0b5",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cfa8d3e236a6e1a41d69712a84d434dfdf70e560",
+                "reference": "cfa8d3e236a6e1a41d69712a84d434dfdf70e560",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0",
-                "phpstan/phpstan": "^1.4.2"
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.5"
             },
             "conflict": {
                 "phpstan/phpdoc-parser": "<1.2",
@@ -888,7 +888,7 @@
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.12.15"
+                "source": "https://github.com/rectorphp/rector/tree/0.12.20"
             },
             "funding": [
                 {
@@ -896,36 +896,102 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T12:02:35+00:00"
+            "time": "2022-04-06T12:55:14+00:00"
         },
         {
-            "name": "slevomat/coding-standard",
-            "version": "7.0.18",
+            "name": "sebastian/diff",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc"
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
-                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "b521bd358b5f7a7d69e9637fd139e036d8adeb6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b521bd358b5f7a7d69e9637fd139e036d8adeb6f",
+                "reference": "b521bd358b5f7a7d69e9637fd139e036d8adeb6f",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.0.0",
-                "squizlabs/php_codesniffer": "^3.6.1"
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.4.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
-                "phing/phing": "2.17.0",
-                "php-parallel-lint/php-parallel-lint": "1.3.1",
-                "phpstan/phpstan": "1.2.0",
+                "phing/phing": "2.17.2",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.5.2",
                 "phpstan/phpstan-deprecation-rules": "1.0.0",
-                "phpstan/phpstan-phpunit": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.0",
                 "phpstan/phpstan-strict-rules": "1.1.0",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.10"
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.19"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -945,7 +1011,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.0.18"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.1"
             },
             "funding": [
                 {
@@ -957,7 +1023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-07T17:19:06+00:00"
+            "time": "2022-03-29T12:44:16+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1017,35 +1083,34 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.4.2",
+            "version": "v6.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "2e082dae50da563c639119b7b52347a2a3db4ba5"
+                "reference": "22850bfdd2b6090568ad05dece6843c859d933b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/2e082dae50da563c639119b7b52347a2a3db4ba5",
-                "reference": "2e082dae50da563c639119b7b52347a2a3db4ba5",
+                "url": "https://api.github.com/repos/symfony/config/zipball/22850bfdd2b6090568ad05dece6843c859d933b7",
+                "reference": "22850bfdd2b6090568ad05dece6843c859d933b7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/filesystem": "^4.4|^5.0|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-php80": "^1.16",
                 "symfony/polyfill-php81": "^1.22"
             },
             "conflict": {
                 "symfony/finder": "<4.4"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
-                "symfony/finder": "^4.4|^5.0|^6.0",
-                "symfony/messenger": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/messenger": "^5.4|^6.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/yaml": "^4.4|^5.0|^6.0"
+                "symfony/yaml": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -1076,7 +1141,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.4.2"
+                "source": "https://github.com/symfony/config/tree/v6.0.7"
             },
             "funding": [
                 {
@@ -1092,20 +1157,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-15T11:06:13+00:00"
+            "time": "2022-03-22T16:12:04+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.2",
+            "version": "v6.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "dd434fa8d69325e5d210f63070014d889511fcb3"
+                "reference": "70dcf7b2ca2ea08ad6ebcc475f104a024fb5632e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/dd434fa8d69325e5d210f63070014d889511fcb3",
-                "reference": "dd434fa8d69325e5d210f63070014d889511fcb3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/70dcf7b2ca2ea08ad6ebcc475f104a024fb5632e",
+                "reference": "70dcf7b2ca2ea08ad6ebcc475f104a024fb5632e",
                 "shasum": ""
             },
             "require": {
@@ -1171,7 +1236,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.2"
+                "source": "https://github.com/symfony/console/tree/v6.0.7"
             },
             "funding": [
                 {
@@ -1187,45 +1252,44 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-27T21:05:08+00:00"
+            "time": "2022-03-31T17:18:25+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.4.2",
+            "version": "v6.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "ba94559be9738d77cd29e24b5d81cf3b89b7d628"
+                "reference": "3e8a405fcc2eaf4eadb25b5e259ad9bf90499848"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/ba94559be9738d77cd29e24b5d81cf3b89b7d628",
-                "reference": "ba94559be9738d77cd29e24b5d81cf3b89b7d628",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/3e8a405fcc2eaf4eadb25b5e259ad9bf90499848",
+                "reference": "3e8a405fcc2eaf4eadb25b5e259ad9bf90499848",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1.1",
+                "php": ">=8.0.2",
+                "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16",
                 "symfony/polyfill-php81": "^1.22",
-                "symfony/service-contracts": "^1.1.6|^2"
+                "symfony/service-contracts": "^1.1.6|^2.0|^3.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
-                "symfony/config": "<5.3",
-                "symfony/finder": "<4.4",
-                "symfony/proxy-manager-bridge": "<4.4",
-                "symfony/yaml": "<4.4"
+                "symfony/config": "<5.4",
+                "symfony/finder": "<5.4",
+                "symfony/proxy-manager-bridge": "<5.4",
+                "symfony/yaml": "<5.4"
             },
             "provide": {
-                "psr/container-implementation": "1.0",
-                "symfony/service-implementation": "1.0|2.0"
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
             },
             "require-dev": {
-                "symfony/config": "^5.3|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/yaml": "^4.4|^5.0|^6.0"
+                "symfony/config": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/config": "",
@@ -1260,7 +1324,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.2"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.0.7"
             },
             "funding": [
                 {
@@ -1276,20 +1340,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-29T10:10:35+00:00"
+            "time": "2022-03-08T15:43:52+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.0",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "c726b64c1ccfe2896cb7df2e1331c357ad1c8ced"
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/c726b64c1ccfe2896cb7df2e1331c357ad1c8ced",
-                "reference": "c726b64c1ccfe2896cb7df2e1331c357ad1c8ced",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
                 "shasum": ""
             },
             "require": {
@@ -1327,7 +1391,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.1"
             },
             "funding": [
                 {
@@ -1343,27 +1407,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-01T23:48:49+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.0",
+            "version": "v6.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "731f917dc31edcffec2c6a777f3698c33bea8f01"
+                "reference": "6c9e4c41f2c51dfde3db298594ed9cba55dbf5ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/731f917dc31edcffec2c6a777f3698c33bea8f01",
-                "reference": "731f917dc31edcffec2c6a777f3698c33bea8f01",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6c9e4c41f2c51dfde3db298594ed9cba55dbf5ff",
+                "reference": "6c9e4c41f2c51dfde3db298594ed9cba55dbf5ff",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8",
-                "symfony/polyfill-php80": "^1.16"
+                "symfony/polyfill-mbstring": "~1.8"
             },
             "type": "library",
             "autoload": {
@@ -1391,7 +1454,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.0"
+                "source": "https://github.com/symfony/filesystem/tree/v6.0.7"
             },
             "funding": [
                 {
@@ -1407,20 +1470,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-28T13:39:27+00:00"
+            "time": "2022-04-01T12:54:51+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "03d2833e677d48317cac852f9c0287fb048c3c5c"
+                "reference": "8661b74dbabc23223f38c9b99d3f8ade71170430"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/03d2833e677d48317cac852f9c0287fb048c3c5c",
-                "reference": "03d2833e677d48317cac852f9c0287fb048c3c5c",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8661b74dbabc23223f38c9b99d3f8ade71170430",
+                "reference": "8661b74dbabc23223f38c9b99d3f8ade71170430",
                 "shasum": ""
             },
             "require": {
@@ -1452,7 +1515,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.0.2"
+                "source": "https://github.com/symfony/finder/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -1468,11 +1531,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-20T16:21:45+00:00"
+            "time": "2022-01-26T17:23:29+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -1504,12 +1567,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1534,7 +1597,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1554,7 +1617,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -1583,12 +1646,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1615,7 +1678,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1635,7 +1698,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -1664,12 +1727,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -1699,7 +1762,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1719,7 +1782,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -1751,12 +1814,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1782,7 +1845,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1801,91 +1864,8 @@
             "time": "2021-11-30T18:21:41+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.24.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/57b712b08eddb97c762a8caa32c84e037892d2e9",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.24.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-09-13T13:58:33+00:00"
-        },
-        {
             "name": "symfony/polyfill-php81",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -1911,12 +1891,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -1944,7 +1924,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1964,21 +1944,21 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.4.1",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d664541b99d6fb0247ec5ff32e87238582236204"
+                "reference": "e517458f278c2131ca9f262f8fbaf01410f2c65c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d664541b99d6fb0247ec5ff32e87238582236204",
-                "reference": "d664541b99d6fb0247ec5ff32e87238582236204",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e517458f278c2131ca9f262f8fbaf01410f2c65c",
+                "reference": "e517458f278c2131ca9f262f8fbaf01410f2c65c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1"
+                "php": ">=8.0.2",
+                "psr/container": "^2.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -1989,7 +1969,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2026,7 +2006,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.4.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.0.1"
             },
             "funding": [
                 {
@@ -2042,20 +2022,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-04T16:37:19+00:00"
+            "time": "2022-03-13T20:10:05+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "bae261d0c3ac38a1f802b4dfed42094296100631"
+                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/bae261d0c3ac38a1f802b4dfed42094296100631",
-                "reference": "bae261d0c3ac38a1f802b4dfed42094296100631",
+                "url": "https://api.github.com/repos/symfony/string/zipball/522144f0c4c004c80d56fa47e40e17028e2eefc2",
+                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2",
                 "shasum": ""
             },
             "require": {
@@ -2076,12 +2056,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -2111,7 +2091,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.2"
+                "source": "https://github.com/symfony/string/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -2127,71 +2107,69 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T22:13:01+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symplify/astral",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/astral.git",
-                "reference": "f20a6d13e40aa5c55057aadcd8d2b72d04d04faa"
+                "reference": "f4937420a624cb4f73c9dfe5117def17eb5b5c24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/astral/zipball/f20a6d13e40aa5c55057aadcd8d2b72d04d04faa",
-                "reference": "f20a6d13e40aa5c55057aadcd8d2b72d04d04faa",
+                "url": "https://api.github.com/repos/symplify/astral/zipball/f4937420a624cb4f73c9dfe5117def17eb5b5c24",
+                "reference": "f4937420a624cb4f73c9dfe5117def17eb5b5c24",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "nikic/php-parser": "^4.13.2",
                 "php": ">=8.0",
-                "phpstan/phpstan": "^1.3",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symplify/package-builder": "^10.0.19",
-                "symplify/smart-file-system": "^10.0.19",
-                "symplify/symplify-kernel": "^10.0.19"
+                "phpstan/phpdoc-parser": "^1.2",
+                "phpstan/phpstan": "^1.4.8",
+                "symfony/config": "^6.0",
+                "symfony/dependency-injection": "^6.0",
+                "symplify/package-builder": "^10.1.4",
+                "symplify/smart-file-system": "^10.1.4",
+                "symplify/symplify-kernel": "^10.1.4"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
+                "symplify/amnesia": "<10.1.4",
+                "symplify/autowire-array-parameter": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/composer-json-manipulator": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/easy-testing": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-extensions": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/phpstan-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/rule-doc-generator-contracts": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
                 "symplify/smart-file-system": "<9.4.70",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
+                "symplify/symfony-static-dumper": "<10.1.4",
                 "symplify/symplify-kernel": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5",
-                "symplify/easy-testing": "^10.0.19"
+                "symplify/easy-testing": "^10.1.4"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -2210,7 +2188,7 @@
             ],
             "description": "Toolking for smart daily work with AST",
             "support": {
-                "source": "https://github.com/symplify/astral/tree/10.0.19"
+                "source": "https://github.com/symplify/astral/tree/10.1.4"
             },
             "funding": [
                 {
@@ -2222,58 +2200,54 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:17:57+00:00"
+            "time": "2022-03-16T15:16:17+00:00"
         },
         {
             "name": "symplify/autowire-array-parameter",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/autowire-array-parameter.git",
-                "reference": "f061a74328d04ef2d3784af5c324576bcc89e6bd"
+                "reference": "5e34739bbc7e2ff2e1ad92e088080feaee22be25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/f061a74328d04ef2d3784af5c324576bcc89e6bd",
-                "reference": "f061a74328d04ef2d3784af5c324576bcc89e6bd",
+                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/5e34739bbc7e2ff2e1ad92e088080feaee22be25",
+                "reference": "5e34739bbc7e2ff2e1ad92e088080feaee22be25",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symplify/package-builder": "^10.0.19"
+                "symfony/dependency-injection": "^6.0",
+                "symplify/package-builder": "^10.1.4"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/smart-file-system": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/symplify-kernel": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.4",
+                "symplify/astral": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/composer-json-manipulator": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/easy-testing": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-extensions": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/phpstan-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/rule-doc-generator-contracts": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
+                "symplify/smart-file-system": "<10.1.4",
+                "symplify/symfony-static-dumper": "<10.1.4",
+                "symplify/symplify-kernel": "<10.1.4",
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2281,7 +2255,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -2295,7 +2269,7 @@
             ],
             "description": "Autowire array parameters for your Symfony applications",
             "support": {
-                "source": "https://github.com/symplify/autowire-array-parameter/tree/10.0.19"
+                "source": "https://github.com/symplify/autowire-array-parameter/tree/10.1.4"
             },
             "funding": [
                 {
@@ -2307,61 +2281,57 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:17:42+00:00"
+            "time": "2022-03-16T15:16:12+00:00"
         },
         {
             "name": "symplify/composer-json-manipulator",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/composer-json-manipulator.git",
-                "reference": "172a37a51be9cb6da214817bb0a8ed6188d29568"
+                "reference": "efc63dc656f9dece03d06c76bf7c4bc24d06916a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/172a37a51be9cb6da214817bb0a8ed6188d29568",
-                "reference": "172a37a51be9cb6da214817bb0a8ed6188d29568",
+                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/efc63dc656f9dece03d06c76bf7c4bc24d06916a",
+                "reference": "efc63dc656f9dece03d06c76bf7c4bc24d06916a",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symplify/package-builder": "^10.0.19",
-                "symplify/smart-file-system": "^10.0.19",
-                "symplify/symplify-kernel": "^10.0.19"
+                "symfony/config": "^6.0",
+                "symfony/dependency-injection": "^6.0",
+                "symfony/filesystem": "^6.0",
+                "symplify/package-builder": "^10.1.4",
+                "symplify/smart-file-system": "^10.1.4",
+                "symplify/symplify-kernel": "^10.1.4"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
+                "symplify/amnesia": "<10.1.4",
+                "symplify/astral": "<10.1.4",
+                "symplify/autowire-array-parameter": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/easy-testing": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-extensions": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/phpstan-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/rule-doc-generator-contracts": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
+                "symplify/symfony-static-dumper": "<10.1.4",
                 "symplify/symplify-kernel": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2369,7 +2339,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -2383,7 +2353,7 @@
             ],
             "description": "Package to load, merge and save composer.json file(s)",
             "support": {
-                "source": "https://github.com/symplify/composer-json-manipulator/tree/10.0.19"
+                "source": "https://github.com/symplify/composer-json-manipulator/tree/10.1.4"
             },
             "funding": [
                 {
@@ -2395,20 +2365,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:18:10+00:00"
+            "time": "2022-03-16T15:16:28+00:00"
         },
         {
             "name": "symplify/easy-coding-standard",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-coding-standard.git",
-                "reference": "f38070ac6ec8c83ccabc51147c2089890a38ed7c"
+                "reference": "3fdbead9da24889727dc11804e9bbfb9d4502d3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/f38070ac6ec8c83ccabc51147c2089890a38ed7c",
-                "reference": "f38070ac6ec8c83ccabc51147c2089890a38ed7c",
+                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/3fdbead9da24889727dc11804e9bbfb9d4502d3a",
+                "reference": "3fdbead9da24889727dc11804e9bbfb9d4502d3a",
                 "shasum": ""
             },
             "require": {
@@ -2438,7 +2408,7 @@
             ],
             "description": "Prefixed scoped version of ECS package",
             "support": {
-                "source": "https://github.com/symplify/easy-coding-standard/tree/10.0.19"
+                "source": "https://github.com/symplify/easy-coding-standard/tree/10.1.4"
             },
             "funding": [
                 {
@@ -2450,60 +2420,56 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:15:43+00:00"
+            "time": "2022-03-16T15:18:55+00:00"
         },
         {
             "name": "symplify/easy-testing",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-testing.git",
-                "reference": "8781307d0f5554e149aab653f3ffb0b77b6ba17d"
+                "reference": "920d59d2be2df1f23f06261cf1f94b701a4497c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/8781307d0f5554e149aab653f3ffb0b77b6ba17d",
-                "reference": "8781307d0f5554e149aab653f3ffb0b77b6ba17d",
+                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/920d59d2be2df1f23f06261cf1f94b701a4497c8",
+                "reference": "920d59d2be2df1f23f06261cf1f94b701a4497c8",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symplify/package-builder": "^10.0.19",
-                "symplify/smart-file-system": "^10.0.19",
-                "symplify/symplify-kernel": "^10.0.19"
+                "symfony/console": "^6.0",
+                "symfony/dependency-injection": "^6.0",
+                "symfony/finder": "^6.0",
+                "symplify/package-builder": "^10.1.4",
+                "symplify/smart-file-system": "^10.1.4",
+                "symplify/symplify-kernel": "^10.1.4"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.4",
+                "symplify/astral": "<10.1.4",
+                "symplify/autowire-array-parameter": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/composer-json-manipulator": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-extensions": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/phpstan-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/rule-doc-generator-contracts": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
+                "symplify/symfony-static-dumper": "<10.1.4",
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2514,7 +2480,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -2528,7 +2494,7 @@
             ],
             "description": "Testing made easy",
             "support": {
-                "source": "https://github.com/symplify/easy-testing/tree/10.0.19"
+                "source": "https://github.com/symplify/easy-testing/tree/10.1.4"
             },
             "funding": [
                 {
@@ -2540,62 +2506,59 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:18:23+00:00"
+            "time": "2022-03-16T15:16:34+00:00"
         },
         {
             "name": "symplify/package-builder",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/package-builder.git",
-                "reference": "1d52662633d527369462571c62d40a03f8e538f3"
+                "reference": "1d19b244020306080c61e548dd8bf09ee95a6ab8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/package-builder/zipball/1d52662633d527369462571c62d40a03f8e538f3",
-                "reference": "1d52662633d527369462571c62d40a03f8e538f3",
+                "url": "https://api.github.com/repos/symplify/package-builder/zipball/1d19b244020306080c61e548dd8bf09ee95a6ab8",
+                "reference": "1d19b244020306080c61e548dd8bf09ee95a6ab8",
                 "shasum": ""
             },
             "require": {
                 "nette/neon": "^3.3.2",
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symplify/easy-testing": "^10.0.19",
-                "symplify/symplify-kernel": "^10.0.19"
+                "sebastian/diff": "^4.0",
+                "symfony/config": "^6.0",
+                "symfony/console": "^6.0",
+                "symfony/dependency-injection": "^6.0",
+                "symfony/finder": "^6.0",
+                "symplify/easy-testing": "^10.1.4",
+                "symplify/symplify-kernel": "^10.1.4"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/smart-file-system": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.4",
+                "symplify/astral": "<10.1.4",
+                "symplify/autowire-array-parameter": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/composer-json-manipulator": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-extensions": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/phpstan-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/rule-doc-generator-contracts": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
+                "symplify/smart-file-system": "<10.1.4",
+                "symplify/symfony-static-dumper": "<10.1.4",
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2603,7 +2566,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -2617,7 +2580,7 @@
             ],
             "description": "Dependency Injection, Console and Kernel toolkit for Symplify packages.",
             "support": {
-                "source": "https://github.com/symplify/package-builder/tree/10.0.19"
+                "source": "https://github.com/symplify/package-builder/tree/10.1.4"
             },
             "funding": [
                 {
@@ -2629,57 +2592,53 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:18:43+00:00"
+            "time": "2022-03-16T15:16:33+00:00"
         },
         {
             "name": "symplify/phpstan-extensions",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/phpstan-extensions.git",
-                "reference": "6bd846510b4002d61ec52f72ad93480ed208c832"
+                "reference": "3d1b7ed1557f9b1ad9d4815e49b085d58aadec2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/phpstan-extensions/zipball/6bd846510b4002d61ec52f72ad93480ed208c832",
-                "reference": "6bd846510b4002d61ec52f72ad93480ed208c832",
+                "url": "https://api.github.com/repos/symplify/phpstan-extensions/zipball/3d1b7ed1557f9b1ad9d4815e49b085d58aadec2a",
+                "reference": "3d1b7ed1557f9b1ad9d4815e49b085d58aadec2a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
-                "phpstan/phpstan": "^1.3",
-                "symplify/astral": "^10.0.19",
-                "symplify/package-builder": "^10.0.19",
-                "symplify/smart-file-system": "^10.0.19"
+                "phpstan/phpstan": "^1.4.8",
+                "symplify/astral": "^10.1.4",
+                "symplify/package-builder": "^10.1.4",
+                "symplify/smart-file-system": "^10.1.4"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/symplify-kernel": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.4",
+                "symplify/autowire-array-parameter": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/composer-json-manipulator": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/easy-testing": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/phpstan-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/rule-doc-generator-contracts": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
+                "symplify/symfony-static-dumper": "<10.1.4",
+                "symplify/symplify-kernel": "<10.1.4",
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2687,7 +2646,7 @@
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -2706,7 +2665,7 @@
             ],
             "description": "Pre-escaped error messages in 'symplify' error format, container aware test case and other useful extensions for PHPStan",
             "support": {
-                "source": "https://github.com/symplify/phpstan-extensions/tree/10.0.19"
+                "source": "https://github.com/symplify/phpstan-extensions/tree/10.1.4"
             },
             "funding": [
                 {
@@ -2718,20 +2677,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:18:51+00:00"
+            "time": "2022-03-16T15:16:40+00:00"
         },
         {
             "name": "symplify/phpstan-rules",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/phpstan-rules.git",
-                "reference": "310a0a9e75ae929f5aab29abfcb5547f520c00c8"
+                "reference": "7e4740af17eb93b30cb5222b8b5eea945e93a4c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/phpstan-rules/zipball/310a0a9e75ae929f5aab29abfcb5547f520c00c8",
-                "reference": "310a0a9e75ae929f5aab29abfcb5547f520c00c8",
+                "url": "https://api.github.com/repos/symplify/phpstan-rules/zipball/7e4740af17eb93b30cb5222b8b5eea945e93a4c8",
+                "reference": "7e4740af17eb93b30cb5222b8b5eea945e93a4c8",
                 "shasum": ""
             },
             "require": {
@@ -2739,53 +2698,49 @@
                 "nikic/php-parser": "^4.13.2",
                 "php": ">=8.0",
                 "phpstan/phpdoc-parser": "^1.2",
-                "phpstan/phpstan": "^1.3",
-                "symplify/astral": "^10.0.19",
-                "symplify/composer-json-manipulator": "^10.0.19",
-                "symplify/package-builder": "^10.0.19",
-                "symplify/rule-doc-generator-contracts": "^10.0.19",
-                "symplify/simple-php-doc-parser": "^10.0.19",
-                "symplify/smart-file-system": "^10.0.19",
+                "phpstan/phpstan": "^1.4.8",
+                "symplify/astral": "^10.1.4",
+                "symplify/composer-json-manipulator": "^10.1.4",
+                "symplify/package-builder": "^10.1.4",
+                "symplify/rule-doc-generator-contracts": "^10.1.4",
+                "symplify/smart-file-system": "^10.1.4",
                 "webmozart/assert": "^1.10"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/symplify-kernel": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.4",
+                "symplify/autowire-array-parameter": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/easy-testing": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-extensions": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
+                "symplify/symfony-static-dumper": "<10.1.4",
+                "symplify/symplify-kernel": "<10.1.4",
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "require-dev": {
                 "myclabs/php-enum": "^1.8",
                 "phpunit/phpunit": "^9.5",
-                "symfony/framework-bundle": "^5.4|^6.0",
-                "symplify/easy-testing": "^10.0.19",
-                "symplify/phpstan-extensions": "^10.0.19",
-                "symplify/rule-doc-generator": "^10.0.19"
+                "symfony/framework-bundle": "^6.0",
+                "symplify/easy-testing": "^10.1.4",
+                "symplify/phpstan-extensions": "^10.1.4",
+                "symplify/rule-doc-generator": "^10.1.4"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -2799,10 +2754,10 @@
             "autoload": {
                 "psr-4": {
                     "Symplify\\PHPStanRules\\": "src",
-                    "Symplify\\PHPStanRules\\CognitiveComplexity\\": "packages/cognitive-complexity/src",
-                    "Symplify\\PHPStanRules\\ObjectCalisthenics\\": "packages/object-calisthenics/src",
+                    "Symplify\\PHPStanRules\\Nette\\": "packages/nette/src",
                     "Symplify\\PHPStanRules\\Symfony\\": "packages/symfony/src",
-                    "Symplify\\PHPStanRules\\Nette\\": "packages/nette/src"
+                    "Symplify\\PHPStanRules\\ObjectCalisthenics\\": "packages/object-calisthenics/src",
+                    "Symplify\\PHPStanRules\\CognitiveComplexity\\": "packages/cognitive-complexity/src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2811,7 +2766,7 @@
             ],
             "description": "Set of Symplify rules for PHPStan",
             "support": {
-                "source": "https://github.com/symplify/phpstan-rules/tree/10.0.19"
+                "source": "https://github.com/symplify/phpstan-rules/tree/10.1.4"
             },
             "funding": [
                 {
@@ -2823,20 +2778,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:19:04+00:00"
+            "time": "2022-03-16T15:17:53+00:00"
         },
         {
             "name": "symplify/rule-doc-generator-contracts",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/rule-doc-generator-contracts.git",
-                "reference": "4836791e312d7cf61e037deab8c87e12eb646639"
+                "reference": "101be8c7f09c8d3406227f02860bb8147e428912"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/rule-doc-generator-contracts/zipball/4836791e312d7cf61e037deab8c87e12eb646639",
-                "reference": "4836791e312d7cf61e037deab8c87e12eb646639",
+                "url": "https://api.github.com/repos/symplify/rule-doc-generator-contracts/zipball/101be8c7f09c8d3406227f02860bb8147e428912",
+                "reference": "101be8c7f09c8d3406227f02860bb8147e428912",
                 "shasum": ""
             },
             "require": {
@@ -2844,41 +2799,37 @@
                 "php": ">=8.0"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/package-builder": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/smart-file-system": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/symplify-kernel": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.4",
+                "symplify/astral": "<10.1.4",
+                "symplify/autowire-array-parameter": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/composer-json-manipulator": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/easy-testing": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/package-builder": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-extensions": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/phpstan-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
+                "symplify/smart-file-system": "<10.1.4",
+                "symplify/symfony-static-dumper": "<10.1.4",
+                "symplify/symplify-kernel": "<10.1.4",
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -2892,7 +2843,7 @@
             ],
             "description": "Contracts for production code of RuleDocGenerator",
             "support": {
-                "source": "https://github.com/symplify/rule-doc-generator-contracts/tree/10.0.19"
+                "source": "https://github.com/symplify/rule-doc-generator-contracts/tree/10.1.4"
             },
             "funding": [
                 {
@@ -2904,146 +2855,55 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:19:01+00:00"
-        },
-        {
-            "name": "symplify/simple-php-doc-parser",
-            "version": "10.0.19",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symplify/simple-php-doc-parser.git",
-                "reference": "46ea49814891a620908a919912653b7449833952"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symplify/simple-php-doc-parser/zipball/46ea49814891a620908a919912653b7449833952",
-                "reference": "46ea49814891a620908a919912653b7449833952",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0",
-                "phpstan/phpdoc-parser": "^1.2",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symplify/package-builder": "^10.0.19"
-            },
-            "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/smart-file-system": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/symplify-kernel": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "symplify/easy-testing": "^10.0.19"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "10.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symplify\\SimplePhpDocParser\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Service integration of phpstan/phpdoc-parser, with few extra goodies for practical simple use",
-            "support": {
-                "source": "https://github.com/symplify/simple-php-doc-parser/tree/10.0.19"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.me/rectorphp",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/tomasvotruba",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-01-26T01:19:05+00:00"
+            "time": "2022-03-16T15:17:07+00:00"
         },
         {
             "name": "symplify/smart-file-system",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/smart-file-system.git",
-                "reference": "ddf5369d240f7da11f570815308326fce2ecf6d3"
+                "reference": "79757341c13ea61b8cecdb3214b9fbe67e593284"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/ddf5369d240f7da11f570815308326fce2ecf6d3",
-                "reference": "ddf5369d240f7da11f570815308326fce2ecf6d3",
+                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/79757341c13ea61b8cecdb3214b9fbe67e593284",
+                "reference": "79757341c13ea61b8cecdb3214b9fbe67e593284",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0"
+                "symfony/filesystem": "^6.0",
+                "symfony/finder": "^6.0"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/package-builder": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/symplify-kernel": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.4",
+                "symplify/astral": "<10.1.4",
+                "symplify/autowire-array-parameter": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/composer-json-manipulator": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/easy-testing": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/package-builder": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-extensions": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/phpstan-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/rule-doc-generator-contracts": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
+                "symplify/symfony-static-dumper": "<10.1.4",
+                "symplify/symplify-kernel": "<10.1.4",
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "require-dev": {
                 "nette/finder": "^2.5",
@@ -3052,7 +2912,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -3066,7 +2926,7 @@
             ],
             "description": "Sanitized FileInfo with safe getRealPath() and other handy methods",
             "support": {
-                "source": "https://github.com/symplify/smart-file-system/tree/10.0.19"
+                "source": "https://github.com/symplify/smart-file-system/tree/10.1.4"
             },
             "funding": [
                 {
@@ -3078,59 +2938,55 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:19:23+00:00"
+            "time": "2022-03-16T15:17:16+00:00"
         },
         {
             "name": "symplify/symplify-kernel",
-            "version": "10.0.19",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/symplify-kernel.git",
-                "reference": "f76582143cdc4365451ee98ed1a9e43ba19e3af1"
+                "reference": "dbefe488cedafe5a637d37e4dd61f238daa8da0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/f76582143cdc4365451ee98ed1a9e43ba19e3af1",
-                "reference": "f76582143cdc4365451ee98ed1a9e43ba19e3af1",
+                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/dbefe488cedafe5a637d37e4dd61f238daa8da0f",
+                "reference": "dbefe488cedafe5a637d37e4dd61f238daa8da0f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symplify/autowire-array-parameter": "^10.0.19",
-                "symplify/composer-json-manipulator": "^10.0.19",
-                "symplify/package-builder": "^10.0.19",
-                "symplify/smart-file-system": "^10.0.19",
+                "symfony/console": "^6.0",
+                "symfony/dependency-injection": "^6.0",
+                "symplify/autowire-array-parameter": "^10.1.4",
+                "symplify/composer-json-manipulator": "^10.1.4",
+                "symplify/package-builder": "^10.1.4",
+                "symplify/smart-file-system": "^10.1.4",
                 "webmozart/assert": "^1.10"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.4",
+                "symplify/astral": "<10.1.4",
+                "symplify/coding-standard": "<10.1.4",
+                "symplify/config-transformer": "<10.1.4",
+                "symplify/easy-ci": "<10.1.4",
+                "symplify/easy-coding-standard": "<10.1.4",
+                "symplify/easy-parallel": "<10.1.4",
+                "symplify/easy-testing": "<10.1.4",
+                "symplify/git-wrapper": "<10.1.4",
+                "symplify/latte-phpstan-compiler": "<10.1.4",
+                "symplify/monorepo-builder": "<10.1.4",
+                "symplify/neon-config-dumper": "<10.1.4",
+                "symplify/php-config-printer": "<10.1.4",
+                "symplify/phpstan-extensions": "<10.1.4",
+                "symplify/phpstan-latte-rules": "<10.1.4",
+                "symplify/phpstan-rules": "<10.1.4",
+                "symplify/rule-doc-generator": "<10.1.4",
+                "symplify/rule-doc-generator-contracts": "<10.1.4",
+                "symplify/skipper": "<10.1.4",
+                "symplify/symfony-static-dumper": "<10.1.4",
+                "symplify/template-phpstan-compiler": "<10.1.4",
+                "symplify/vendor-patches": "<10.1.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3138,7 +2994,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -3152,9 +3008,9 @@
             ],
             "description": "Internal Kernel for Symplify packages",
             "support": {
-                "source": "https://github.com/symplify/symplify-kernel/tree/10.0.19"
+                "source": "https://github.com/symplify/symplify-kernel/tree/10.1.4"
             },
-            "time": "2022-01-26T01:19:35+00:00"
+            "time": "2022-03-16T15:17:14+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -3218,29 +3074,30 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -3267,7 +3124,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
             "funding": [
                 {
@@ -3283,38 +3140,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+            },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3330,7 +3191,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
             "funding": [
                 {
@@ -3338,7 +3199,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3402,16 +3263,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
@@ -3447,9 +3308,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "time": "2021-02-23T14:00:09+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3563,16 +3424,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
@@ -3607,9 +3468,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2022-01-04T19:58:01+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -3680,16 +3541,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.10",
+            "version": "9.2.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
                 "shasum": ""
             },
             "require": {
@@ -3745,7 +3606,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
             },
             "funding": [
                 {
@@ -3753,7 +3614,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-05T09:12:13+00:00"
+            "time": "2022-03-07T09:28:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3998,16 +3859,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.13",
+            "version": "9.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "597cb647654ede35e43b137926dfdfef0fb11743"
+                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/597cb647654ede35e43b137926dfdfef0fb11743",
-                "reference": "597cb647654ede35e43b137926dfdfef0fb11743",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
                 "shasum": ""
             },
             "require": {
@@ -4023,7 +3884,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.7",
+                "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -4037,7 +3898,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3.4",
+                "sebastian/type": "^3.0",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -4058,11 +3919,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4085,7 +3946,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
             },
             "funding": [
                 {
@@ -4097,7 +3958,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-24T07:33:35+00:00"
+            "time": "2022-04-01T12:37:26+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4398,83 +4259,17 @@
             "time": "2020-10-26T15:52:27+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:10:38+00:00"
-        },
-        {
             "name": "sebastian/environment",
-            "version": "5.1.3",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
                 "shasum": ""
             },
             "require": {
@@ -4516,7 +4311,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
             },
             "funding": [
                 {
@@ -4524,7 +4319,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:52:38+00:00"
+            "time": "2022-04-03T09:37:03+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4605,16 +4400,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.3",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
                 "shasum": ""
             },
             "require": {
@@ -4657,7 +4452,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
             },
             "funding": [
                 {
@@ -4665,7 +4460,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T13:31:12+00:00"
+            "time": "2022-02-14T08:28:10+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4956,28 +4751,28 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5000,7 +4795,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
             },
             "funding": [
                 {
@@ -5008,7 +4803,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-15T12:49:02+00:00"
+            "time": "2022-03-15T09:54:48+00:00"
         },
         {
             "name": "sebastian/version",
@@ -5123,5 +4918,5 @@
         "php": "~8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/Sniffs/Commenting/DocCommentSpacingSniff.php
+++ b/src/Sniffs/Commenting/DocCommentSpacingSniff.php
@@ -13,6 +13,9 @@ use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff as SlevomatDocCommentSpacingSniff;
 
+/**
+ * @deprecated Use SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff instead
+ */
 class DocCommentSpacingSniff extends SlevomatDocCommentSpacingSniff
 {
     /** @var string[][]|null */


### PR DESCRIPTION
Since [the PR](https://github.com/slevomat/coding-standard/pull/1277) is merged we don't need our own `EonX\EasyQuality\Sniffs\Commenting\DocCommentSpacingSniff` class. 

Let's use DocCommentSpacingSniff from slevomat repository