### PR TITLE
[ECS] Add an `export` operation to `SortedApiResourceOperationKeysSniff`

### DIFF
--- a/src/Sniffs/Attributes/SortedApiResourceOperationKeysSniff.php
+++ b/src/Sniffs/Attributes/SortedApiResourceOperationKeysSniff.php
@@ -139,6 +139,7 @@ final class SortedApiResourceOperationKeysSniff implements Sniff
     private function getRanks(string $name): array
     {
         return [
+            $name !== 'export',
             $name !== 'get',
             $name !== 'post',
             $name !== 'put',

--- a/tests/Sniffs/Attributes/SortedApiResourceOperationKeysSniff/Fixtures/Correct.php.inc
+++ b/tests/Sniffs/Attributes/SortedApiResourceOperationKeysSniff/Fixtures/Correct.php.inc
@@ -2,6 +2,7 @@
 
 #[ApiResource(
     collectionOperations: [
+        'export' => 'export',
         'get' => [
             'normalization_context' => [
                 'some-context' => 'some-data',


### PR DESCRIPTION
In PBA we need a few `export` operations. Such operations should be defined before `get` operations.