### PR TITLE
[ECS] Update LinebreakAfterEqualsSignSniff

### DIFF
--- a/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
+++ b/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
@@ -21,9 +21,19 @@ final class LinebreakAfterEqualsSignSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        $isConstant = false;
+        $pointer = $equalsSignPointer;
+        do {
+            $pointer--;
+            if ($tokens[$pointer]['type'] === 'T_CONST') {
+                $isConstant = true;
+                break;
+            }
+        } while ($tokens[$pointer]['line'] === $tokens[$equalsSignPointer]['line']);
+
         $afterEqualsSignToken = $tokens[$equalsSignPointer + 1];
 
-        if ($afterEqualsSignToken['content'] !== "\n") {
+        if ($afterEqualsSignToken['content'] !== "\n" || $isConstant) {
             return;
         }
 

--- a/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc
+++ b/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc
@@ -2,11 +2,11 @@
 
 $someClass =
     new class() {
-
+        private const SOOOOOOME_VEEEEEEEEEEERYYYYYYYYYYYYY_LOOOOOOOOOOONG_COOOOOOOONST_NAAAAAAAAAMEEEEEEEEE =
+            'some value';
     };
 if ('sooooooooooooooooooooooome-veeeeeeeeeeeeeeeeeeeery-loooooooooooooooooooooooooon-striiiiiiiiiiiiiiiiiiiiiiiing' ===
  'some') {
     die();
 }
 ?>
-


### PR DESCRIPTION
- Make LinebreakAfterEqualsSignSniff to skip constants.

this will allow to use long constants names and use the linebreak after equals sign.

```
private const SOOOOOOME_VEEEEEEEEEEERYYYYYYYYYYYYY_LOOOOOOOOOOONG_COOOOOOOONST_NAAAAAAAAAMEEEEEEEEE =
    'some value';