### PR TITLE
[ECS] Add handling and test for abstract methods in ArrangeActAssertSniff

### DIFF
--- a/src/Sniffs/ControlStructures/ArrangeActAssertSniff.php
+++ b/src/Sniffs/ControlStructures/ArrangeActAssertSniff.php
@@ -39,8 +39,12 @@ final class ArrangeActAssertSniff implements Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        /** @var int $openTokenPosition */
         $openTokenPosition = TokenHelper::findNext($phpcsFile, [\T_OPEN_CURLY_BRACKET], $stackPtr);
+
+        if ($openTokenPosition === null) {
+            return;
+        }
+
         $closeTokenPosition = $tokens[$openTokenPosition]['bracket_closer'];
 
         if ($this->isSingleLineMethod($phpcsFile, $openTokenPosition, $closeTokenPosition)) {

--- a/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/ArrangeActAssertSniffTest.php
+++ b/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/ArrangeActAssertSniffTest.php
@@ -18,6 +18,10 @@ final class ArrangeActAssertSniffTest extends AbstractSniffTestCase
      */
     public function provideFixtures(): iterable
     {
+        yield 'Correct, abstract method' => [
+            'filePath' => __DIR__ . '/Fixture/Correct/abstractMethod.php.inc',
+        ];
+
         yield 'Correct, anonymous class with empty line' => [
             'filePath' => __DIR__ . '/Fixture/Correct/anonymousClassWithEmptyLine.php.inc',
         ];

--- a/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/abstractMethod.php.inc
+++ b/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/abstractMethod.php.inc
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Quality\Ecs\ArrangeActAssertSniff\Correct;
+
+abstract class AbstractTestCase
+{
+    abstract public function testSomething(): void;
+}


### PR DESCRIPTION
Abstract methods were not correctly handled in ArrangeActAssertSniff, causing a potential error when an abstract method was encountered. This change adds a check to skip abstract methods at the beginning of the sniff process. A new test case 'Correct, abstract method' has been included to ensure the correctness of this handling.