### PR TITLE
feature/ecs-set-default-value-if-missed-for-nullable-promoted-property

### DIFF
--- a/src/Sniffs/Functions/DisallowNonNullDefaultValueSniff.php
+++ b/src/Sniffs/Functions/DisallowNonNullDefaultValueSniff.php
@@ -27,6 +27,10 @@ final class DisallowNonNullDefaultValueSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         foreach ($parameters as $parameter) {
+            if (isset($parameter['property_readonly']) && $parameter['property_readonly']) {
+                continue;
+            }
+
             if (isset($parameter['property_visibility'], $parameter['default'])) {
                 continue;
             }

--- a/src/Sniffs/Functions/DisallowNonNullDefaultValueSniff.php
+++ b/src/Sniffs/Functions/DisallowNonNullDefaultValueSniff.php
@@ -21,26 +21,17 @@ final class DisallowNonNullDefaultValueSniff implements Sniff
 
     public const REPLACEABLE_TOKENS = [\T_CLOSE_SHORT_ARRAY, \T_STRING, \T_DOUBLE_COLON, \T_NS_SEPARATOR];
 
-    /**
-     * @var string
-     */
-    private const READONLY_PATTERN = '/^(public\s|protected\s|private\s)?readonly\s/';
-
     public function process(File $phpcsFile, $functionPointer): void
     {
         $parameters = $phpcsFile->getMethodParameters($functionPointer);
         $tokens = $phpcsFile->getTokens();
 
         foreach ($parameters as $parameter) {
-            if (isset($parameter['property_visibility'])) {
+            if (isset($parameter['property_visibility'], $parameter['default'])) {
                 continue;
             }
 
             if (isset($parameter['default']) === false && $parameter['nullable_type'] === false) {
-                continue;
-            }
-
-            if (\preg_match(self::READONLY_PATTERN, (string)$parameter['content'])) {
                 continue;
             }
 

--- a/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Correct/ClassMethodMultiLineWithReadOnlyParametersInConstructor.php.inc
+++ b/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Correct/ClassMethodMultiLineWithReadOnlyParametersInConstructor.php.inc
@@ -13,7 +13,7 @@ final class TestClass
         private readonly string $param3 = 'some-value',
         public readonly int $param4,
         private readonly stdClass $param5 = new stdClass(),
-        readonly bool $bool,
+        private readonly ?bool $bool,
         protected readonly mixed $readonly2,
         $readonly,
     ) {

--- a/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Correct/PromotedPropertiesMultiLineParameters.php.inc
+++ b/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Correct/PromotedPropertiesMultiLineParameters.php.inc
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\Sniffs\Functions\DisallowNonNullDefaultValueSniff\Fixture\Correct;
+
+final class TestClass
+{
+    public function __construct(
+        private int $param1,
+        private ?array $param3 = null,
+        private ?int $param4 = 4,
+    ) {
+        // No body needed
+    }
+}

--- a/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Correct/PromotedPropertiesSingleLineParameters.php.inc
+++ b/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Correct/PromotedPropertiesSingleLineParameters.php.inc
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\Sniffs\Functions\DisallowNonNullDefaultValueSniff\Fixture\Correct;
+
+final class TestClass
+{
+    public function __construct(private int $param1, private ?array $param3 = null, private ?int $param4 = 4)
+    {
+        // No body needed
+    }
+}

--- a/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Wrong/PromotedPropertiesMultiLineParameters.php.inc
+++ b/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Wrong/PromotedPropertiesMultiLineParameters.php.inc
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\Sniffs\Functions\DisallowNonNullDefaultValueSniff\Fixture\Correct;
+
+final class TestClass
+{
+    public function __construct(
+        private int $param1,
+        private ?array $param3 = null,
+        private ?int $param4,
+    ) {
+        // No body needed
+    }
+}
+-----
+<?php
+
+declare(strict_types = 1);
+
+namespace EonX\EasyQuality\Tests\Sniffs\Functions\DisallowNonNullDefaultValueSniff\Fixture\Correct;
+
+final class TestClass
+{
+    public function __construct(
+        private int $param1,
+        private ?array $param3 = null,
+        private ?int $param4 = null,
+    ) {
+        // No body needed
+    }
+}

--- a/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Wrong/PromotedPropertiesSingleLineParameters.php.inc
+++ b/tests/Sniffs/Functions/DisallowNonNullDefaultValueSniff/Fixture/Wrong/PromotedPropertiesSingleLineParameters.php.inc
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\Sniffs\Functions\DisallowNonNullDefaultValueSniff\Fixture\Correct;
+
+final class TestClass
+{
+    public function __construct(private int $param1, private ?array $param3 = null, private ?int $param4)
+    {
+        // No body needed
+    }
+}
+-----
+<?php
+
+declare(strict_types = 1);
+
+namespace EonX\EasyQuality\Tests\Sniffs\Functions\DisallowNonNullDefaultValueSniff\Fixture\Correct;
+
+final class TestClass
+{
+    public function __construct(private int $param1, private ?array $param3 = null, private ?int $param4 = null)
+    {
+        // No body needed
+    }
+}


### PR DESCRIPTION
In this commit, the 'DisallowNonNullDefaultValueSniff' class was modified to correctly handle function parameters with property visibility and default values. The unnecessary 'READONLY_PATTERN' property and its usage were removed. This simplifies the parameter handling logic and improves readability.

Additional test fixtures were also created to cover single- and multi-line function parameters in both correct and wrong configurations. These tests ensure that the refactored sniff works appropriately across different use cases.