### PR TITLE
Allow to configure parallel processing

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -52,6 +52,10 @@ jobs:
                     - {name: "Rector module tests", run: sh tests/autoload-patch.sh && vendor/bin/phpunit --testsuit Rector}
                     - {name: "Sniffs module tests", run: vendor/bin/phpunit --testsuit Sniffs}
                     - {name: "composer audit", run: composer audit}
+        env:
+            EONX_EASY_QUALITY_JOB_SIZE: 20
+            EONX_EASY_QUALITY_MAX_NUMBER_OF_PROCESS: 32
+            EONX_EASY_QUALITY_TIMEOUT_SECONDS: 120
         name: ${{ matrix.actions.name}} (${{ matrix.php }})
         steps:
             -   uses: actions/checkout@v4

--- a/config/phpstan/eonx.neon
+++ b/config/phpstan/eonx.neon
@@ -1,3 +1,6 @@
+includes:
+    - phpstan_parallel_settings.php
+
 services:
     -
         class: EonX\EasyQuality\PHPStan\ThrowExceptionMessageRule

--- a/config/phpstan/phpstan_parallel_settings.php
+++ b/config/phpstan/phpstan_parallel_settings.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+use EonX\EasyQuality\Helper\ParallelSettingsResolver;
+
+$config = [];
+$config['parameters']['parallel'] = [
+    'jobSize' => ParallelSettingsResolver::resolveJobSize(),
+    'maximumNumberOfProcesses' => ParallelSettingsResolver::resolveMaxNumberOfProcess(),
+    'processTimeout' => (float)ParallelSettingsResolver::resolveTimeoutSeconds(),
+];
+
+return $config;

--- a/config/phpstan/phpstan_parallel_settings.php
+++ b/config/phpstan/phpstan_parallel_settings.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
 
-use EonX\EasyQuality\Helper\ParallelSettingsResolver;
+use EonX\EasyQuality\Helper\ParallelSettingsHelper;
 
 $config = [];
 $config['parameters']['parallel'] = [
-    'jobSize' => ParallelSettingsResolver::resolveJobSize(),
-    'maximumNumberOfProcesses' => ParallelSettingsResolver::resolveMaxNumberOfProcess(),
-    'processTimeout' => (float)ParallelSettingsResolver::resolveTimeoutSeconds(),
+    'jobSize' => ParallelSettingsHelper::getJobSize(),
+    'maximumNumberOfProcesses' => ParallelSettingsHelper::getMaxNumberOfProcess(),
+    'processTimeout' => (float)ParallelSettingsHelper::getTimeoutSeconds(),
 ];
 
 return $config;

--- a/quality/ecs.php
+++ b/quality/ecs.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use EonX\EasyQuality\Helper\ParallelSettingsResolver;
 use EonX\EasyQuality\Sniffs\Arrays\AlphabeticallySortedArrayKeysSniff;
 use EonX\EasyQuality\Sniffs\Attributes\SortedApiResourceOperationKeysSniff;
 use EonX\EasyQuality\Sniffs\Classes\AvoidPublicPropertiesSniff;
@@ -30,7 +31,11 @@ return ECSConfig::configure()
         __DIR__ . '/ecs.php',
         __DIR__ . '/rector.php',
     ])
-    ->withParallel(300, 32, 20)
+    ->withParallel(
+        ParallelSettingsResolver::resolveTimeoutSeconds(),
+        ParallelSettingsResolver::resolveMaxNumberOfProcess(),
+        ParallelSettingsResolver::resolveJobSize()
+    )
     ->withSets([EasyQualitySetList::ECS])
     ->withSkip([
         'tests/*/Fixture/*',

--- a/quality/ecs.php
+++ b/quality/ecs.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use EonX\EasyQuality\Helper\ParallelSettingsResolver;
+use EonX\EasyQuality\Helper\ParallelSettingsHelper;
 use EonX\EasyQuality\Sniffs\Arrays\AlphabeticallySortedArrayKeysSniff;
 use EonX\EasyQuality\Sniffs\Attributes\SortedApiResourceOperationKeysSniff;
 use EonX\EasyQuality\Sniffs\Classes\AvoidPublicPropertiesSniff;
@@ -32,9 +32,9 @@ return ECSConfig::configure()
         __DIR__ . '/rector.php',
     ])
     ->withParallel(
-        ParallelSettingsResolver::resolveTimeoutSeconds(),
-        ParallelSettingsResolver::resolveMaxNumberOfProcess(),
-        ParallelSettingsResolver::resolveJobSize()
+        ParallelSettingsHelper::getTimeoutSeconds(),
+        ParallelSettingsHelper::getMaxNumberOfProcess(),
+        ParallelSettingsHelper::getJobSize()
     )
     ->withSets([EasyQualitySetList::ECS])
     ->withSkip([

--- a/quality/phpstan.neon
+++ b/quality/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - %currentWorkingDirectory%/vendor/jangregor/phpstan-prophecy/extension.neon
+    - %currentWorkingDirectory%/config/phpstan/eonx.neon
 
 parameters:
     bootstrapFiles:

--- a/quality/rector.php
+++ b/quality/rector.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use EonX\EasyQuality\Helper\ParallelSettingsResolver;
+use EonX\EasyQuality\Helper\ParallelSettingsHelper;
 use EonX\EasyQuality\Rector\AddSeeAnnotationRector;
 use EonX\EasyQuality\Rector\SingleLineCommentRector;
 use EonX\EasyQuality\ValueObject\EasyQualitySetList;
@@ -18,9 +18,9 @@ return RectorConfig::configure()
         __DIR__ . '/rector.php',
     ])
     ->withParallel(
-        ParallelSettingsResolver::resolveTimeoutSeconds(),
-        ParallelSettingsResolver::resolveMaxNumberOfProcess(),
-        ParallelSettingsResolver::resolveJobSize()
+        ParallelSettingsHelper::getTimeoutSeconds(),
+        ParallelSettingsHelper::getMaxNumberOfProcess(),
+        ParallelSettingsHelper::getJobSize()
     )
     ->withImportNames(importDocBlockNames: false)
     ->withPhpSets(php81: true)

--- a/quality/rector.php
+++ b/quality/rector.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use EonX\EasyQuality\Helper\ParallelSettingsResolver;
 use EonX\EasyQuality\Rector\AddSeeAnnotationRector;
 use EonX\EasyQuality\Rector\SingleLineCommentRector;
 use EonX\EasyQuality\ValueObject\EasyQualitySetList;
@@ -16,7 +17,11 @@ return RectorConfig::configure()
         __DIR__ . '/ecs.php',
         __DIR__ . '/rector.php',
     ])
-    ->withParallel(300, 32, 20)
+    ->withParallel(
+        ParallelSettingsResolver::resolveTimeoutSeconds(),
+        ParallelSettingsResolver::resolveMaxNumberOfProcess(),
+        ParallelSettingsResolver::resolveJobSize()
+    )
     ->withImportNames(importDocBlockNames: false)
     ->withPhpSets(php81: true)
     ->withSets([

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,12 @@ This package is a way to centralise reusable classes used for coding standards a
 
 1. Create a `quality` directory in your project root.
 2. Go to the `quality` directory and run `composer require eonx-com/easy-quality`.
-3. Add `quality/vendor` to Git ignore (either in a `.gitignore` file inside the `quality` directory or in you project's root `.gitignore` file).
-4. Update your project's `composer.json` file by adding a post-install script (this will automate an installation of `eonx-com/easy-quality` on all the local machines):
+3. Set env variables to speed up local execution:
+    - `EONX_EASY_QUALITY_JOB_SIZE` - number of files to process in parallel (default: 2)
+    - `EONX_EASY_QUALITY_MAX_NUMBER_OF_PROCESS` - maximum number of parallel processes (default: 4)
+    - `EONX_EASY_QUALITY_TIMEOUT_SECONDS` - timeout in seconds for each process (default: 120)
+4. Add `quality/vendor` to Git ignore (either in a `.gitignore` file inside the `quality` directory or in you project's root `.gitignore` file).
+5. Update your project's `composer.json` file by adding a post-install script (this will automate an installation of `eonx-com/easy-quality` on all the local machines):
 
     ```json
     {
@@ -22,7 +26,7 @@ This package is a way to centralise reusable classes used for coding standards a
     }
     ```
 
-5. Update your project's `composer.json` file by adding the following scripts. Here we use `veewee/composer-run-parallel` (install it as a **dev** dependency) for the `check-all` script to run multiple commands in parallel. Feel free to modiy these
+6. Update your project's `composer.json` file by adding the following scripts. Here we use `veewee/composer-run-parallel` (install it as a **dev** dependency) for the `check-all` script to run multiple commands in parallel. Feel free to modiy these
    commands as you wish.
 
     ```json
@@ -38,9 +42,9 @@ This package is a way to centralise reusable classes used for coding standards a
     }
     ```
 
-6. Make sure you have config files for ECS, Rector, PHP Mess Detector, and PHPStan in the project source code root.
-7. Run `composer check-all` from the project source code root to make sure everything is working and fix the found issues.
-8. If you want to use the quality tools in CI, here is an example of a GitHub action configuration:
+7. Make sure you have config files for ECS, Rector, PHP Mess Detector, and PHPStan in the project source code root.
+8. Run `composer check-all` from the project source code root to make sure everything is working and fix the found issues.
+9. If you want to use the quality tools in CI, here is an example of a GitHub action configuration:
 
     ```yaml
         coding-standards:
@@ -59,6 +63,10 @@ This package is a way to centralise reusable classes used for coding standards a
                         - {name: security, run: composer check-security}
                         - {name: yaml-linter, run: './bin/console lint:yaml config src translations --parse-tags'}
                         - {name: ecs, run: composer check-ecs}
+            env:
+                EONX_EASY_QUALITY_JOB_SIZE: 20
+                EONX_EASY_QUALITY_MAX_NUMBER_OF_PROCESS: 32
+                EONX_EASY_QUALITY_TIMEOUT_SECONDS: 120
     
             name: ${{ matrix.actions.name}} (${{ matrix.php }})
     

--- a/src/Helper/ParallelSettingsHelper.php
+++ b/src/Helper/ParallelSettingsHelper.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyQuality\Helper;
 
-final class ParallelSettingsResolver
+final class ParallelSettingsHelper
 {
     private const DEFAULT_JOB_SIZE = 2;
 
@@ -17,21 +17,21 @@ final class ParallelSettingsResolver
 
     private const ENV_TIMEOUT_SECONDS = 'EONX_EASY_QUALITY_TIMEOUT_SECONDS';
 
-    public static function resolveJobSize(): int
+    public static function getJobSize(): int
     {
         $jobSize = \getenv(self::ENV_JOB_SIZE);
 
         return $jobSize ? (int)$jobSize : self::DEFAULT_JOB_SIZE;
     }
 
-    public static function resolveMaxNumberOfProcess(): int
+    public static function getMaxNumberOfProcess(): int
     {
         $maxNumberOfProcess = \getenv(self::ENV_MAX_NUMBER_OF_PROCESS);
 
         return $maxNumberOfProcess ? (int)$maxNumberOfProcess : self::DEFAULT_MAX_NUMBER_OF_PROCESS;
     }
 
-    public static function resolveTimeoutSeconds(): int
+    public static function getTimeoutSeconds(): int
     {
         $timeoutSeconds = \getenv(self::ENV_TIMEOUT_SECONDS);
 

--- a/src/Helper/ParallelSettingsResolver.php
+++ b/src/Helper/ParallelSettingsResolver.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Helper;
+
+final class ParallelSettingsResolver
+{
+    private const DEFAULT_JOB_SIZE = 2;
+
+    private const DEFAULT_MAX_NUMBER_OF_PROCESS = 4;
+
+    private const DEFAULT_TIMEOUT_SECONDS = 120;
+
+    private const ENV_JOB_SIZE = 'EONX_EASY_QUALITY_JOB_SIZE';
+
+    private const ENV_MAX_NUMBER_OF_PROCESS = 'EONX_EASY_QUALITY_MAX_NUMBER_OF_PROCESS';
+
+    private const ENV_TIMEOUT_SECONDS = 'EONX_EASY_QUALITY_TIMEOUT_SECONDS';
+
+    public static function resolveJobSize(): int
+    {
+        $jobSize = \getenv(self::ENV_JOB_SIZE);
+
+        return $jobSize ? (int)$jobSize : self::DEFAULT_JOB_SIZE;
+    }
+
+    public static function resolveMaxNumberOfProcess(): int
+    {
+        $maxNumberOfProcess = \getenv(self::ENV_MAX_NUMBER_OF_PROCESS);
+
+        return $maxNumberOfProcess ? (int)$maxNumberOfProcess : self::DEFAULT_MAX_NUMBER_OF_PROCESS;
+    }
+
+    public static function resolveTimeoutSeconds(): int
+    {
+        $timeoutSeconds = \getenv(self::ENV_TIMEOUT_SECONDS);
+
+        return $timeoutSeconds ? (int)$timeoutSeconds : self::DEFAULT_TIMEOUT_SECONDS;
+    }
+}


### PR DESCRIPTION
Tests in PG CI

Current minimal settings
ECS - 2m 30s
PHPStan - 5m 40s
Rector - 19m 30s

Mid setting 10, 4, 120
ECS - 2m 25s
PHPStan - 5m 20s
Rector - 5m 40m

Max setting
ECS - 2m 25s
PHPStan - 5m 30s
Rector - 4m 50s