### PR TITLE
Add a rector to automate Named Arguments rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "slevomat/coding-standard": "8.18.0",
         "symplify/easy-coding-standard": "12.5.9",
         "symplify/phpstan-extensions": "12.0.1",
-        "symplify/phpstan-rules": "14.8.0"
+        "symplify/phpstan-rules": "14.8.0",
+        "savinmikhail/add_named_arguments_rector": "^0.1.25"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.50"

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         "phpstan/phpstan": "2.1.33",
         "phpstan/phpstan-strict-rules": "^2.0",
         "rector/rector": "2.3.0",
+        "savinmikhail/add_named_arguments_rector": "^0.1.25",
         "slevomat/coding-standard": "8.18.0",
         "symplify/easy-coding-standard": "12.5.9",
         "symplify/phpstan-extensions": "12.0.1",
-        "symplify/phpstan-rules": "14.8.0",
-        "savinmikhail/add_named_arguments_rector": "^0.1.25"
+        "symplify/phpstan-rules": "14.8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.50"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d81dd6fd2c33c174870725a6176806db",
+    "content-hash": "664e21602c70802571e80a2cdc728e79",
     "packages": [
         {
             "name": "composer/pcre",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a3b06b2c0326a0c780194b31a251322",
+    "content-hash": "d81dd6fd2c33c174870725a6176806db",
     "packages": [
         {
             "name": "composer/pcre",
@@ -396,6 +396,64 @@
                 "source": "https://github.com/nette/utils/tree/v4.1.1"
             },
             "time": "2025-12-22T12:14:32+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -853,6 +911,64 @@
                 }
             ],
             "time": "2025-12-25T22:00:18+00:00"
+        },
+        {
+            "name": "savinmikhail/add_named_arguments_rector",
+            "version": "v0.1.25",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/savinmikhail/AddNamedArgumentsRector.git",
+                "reference": "71aa7a2b1ee93a9f18b12b183979b2b9d214a46e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/savinmikhail/AddNamedArgumentsRector/zipball/71aa7a2b1ee93a9f18b12b183979b2b9d214a46e",
+                "reference": "71aa7a2b1ee93a9f18b12b183979b2b9d214a46e",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.19.4 || ^5.1",
+                "php": ">=8.2",
+                "phpstan/phpstan": "^2.1.5",
+                "rector/rector": "^2.0.9",
+                "symplify/rule-doc-generator-contracts": "^11.2",
+                "webmozart/assert": "^1.11"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.45",
+                "friendsofphp/php-cs-fixer": "^3.68.5",
+                "icanhazstring/composer-unused": "^0.8.11",
+                "maglnet/composer-require-checker": "^4.15",
+                "phpunit/phpunit": "^10.5.45",
+                "phpyh/coding-standard": "^2.6.2",
+                "savinmikhail/dist-size-optimizer": "^0.2.4"
+            },
+            "type": "rector-extension",
+            "autoload": {
+                "psr-4": {
+                    "SavinMikhail\\AddNamedArgumentsRector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Savin Mikhail",
+                    "email": "mikhail.d.savin@gmail.com"
+                }
+            ],
+            "description": "Rector rule to add names to arguments for functions'/methods' calls",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/savinmikhail/AddNamedArgumentsRector/issues",
+                "source": "https://github.com/savinmikhail/AddNamedArgumentsRector/tree/v0.1.25"
+            },
+            "time": "2026-03-19T14:40:48+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -1809,6 +1925,65 @@
             "time": "2025-10-09T15:57:03+00:00"
         },
         {
+            "name": "symplify/rule-doc-generator-contracts",
+            "version": "11.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symplify/rule-doc-generator-contracts.git",
+                "reference": "479cfcfd46047f80624aba931d9789e50475b5c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symplify/rule-doc-generator-contracts/zipball/479cfcfd46047f80624aba931d9789e50475b5c6",
+                "reference": "479cfcfd46047f80624aba931d9789e50475b5c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.2",
+                "rector/rector": "^0.15.10",
+                "symplify/easy-ci": "^11.1",
+                "symplify/easy-coding-standard": "^11.1",
+                "symplify/easy-testing": "^11.1",
+                "symplify/phpstan-extensions": "^11.1",
+                "symplify/phpstan-rules": "11.2.3.72",
+                "tomasvotruba/unused-public": "^0.0.34"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symplify\\RuleDocGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Contracts for production code of RuleDocGenerator",
+            "support": {
+                "source": "https://github.com/symplify/rule-doc-generator-contracts/tree/11.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rectorphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-18T22:02:54+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.12.1",
             "source": {
@@ -1927,64 +2102,6 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v5.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
-            },
-            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/config/rector/eonx-set.php
+++ b/config/rector/eonx-set.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use EonX\EasyQuality\Rector\CompletePartialNamedArgumentsStrategy;
 use EonX\EasyQuality\Rector\ExplicitBoolCompareRector as EonxExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRector;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
@@ -16,6 +17,7 @@ use Rector\Doctrine\TypedCollections\Rector\Class_\InitializeCollectionInConstru
 use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
 use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
+use SavinMikhail\AddNamedArgumentsRector\AddNamedArgumentsRector;
 
 return RectorConfig::configure()
     ->withRules([
@@ -33,4 +35,7 @@ return RectorConfig::configure()
         StrictArraySearchRector::class,
         SimplifyQuoteEscapeRector::class,
         ThrowWithPreviousExceptionRector::class,
+    ])
+    ->withConfiguredRule(AddNamedArgumentsRector::class, [
+        AddNamedArgumentsRector::STRATEGY => CompletePartialNamedArgumentsStrategy::class,
     ]);

--- a/src/Rector/CompletePartialNamedArgumentsStrategy.php
+++ b/src/Rector/CompletePartialNamedArgumentsStrategy.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Rector;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Reflection\ClassReflection;
+use SavinMikhail\AddNamedArgumentsRector\Config\ConfigStrategy;
+use SavinMikhail\AddNamedArgumentsRector\Config\DefaultStrategy;
+
+/**
+ * Only converts calls to named arguments when at least one argument is already named.
+ * Delegates all other checks (variadic, @no-named-arguments, etc.) to DefaultStrategy.
+ */
+final readonly class CompletePartialNamedArgumentsStrategy implements ConfigStrategy
+{
+    /**
+     * @param \PHPStan\Reflection\ExtendedParameterReflection[] $parameters
+     */
+    public static function shouldApply(
+        FuncCall|StaticCall|MethodCall|New_ $node,
+        array $parameters,
+        ?ClassReflection $classReflection = null,
+    ): bool {
+        $hasAtLeastOneNamedArg = false;
+        foreach ($node->args as $arg) {
+            if ($arg instanceof Arg && $arg->name !== null) {
+                $hasAtLeastOneNamedArg = true;
+
+                break;
+            }
+        }
+
+        if ($hasAtLeastOneNamedArg === false) {
+            return false;
+        }
+
+        return DefaultStrategy::shouldApply($node, $parameters, $classReflection);
+    }
+}

--- a/tests/Rector/CompletePartialNamedArgumentsStrategy/CompletePartialNamedArgumentsStrategyTest.php
+++ b/tests/Rector/CompletePartialNamedArgumentsStrategy/CompletePartialNamedArgumentsStrategyTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\Rector\CompletePartialNamedArgumentsStrategy;
+
+use EonX\EasyQuality\Rector\CompletePartialNamedArgumentsStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+#[CoversClass(CompletePartialNamedArgumentsStrategy::class)]
+final class CompletePartialNamedArgumentsStrategyTest extends AbstractRectorTestCase
+{
+    /**
+     * @return iterable<string, array{filePath: string}>
+     *
+     * @see testRule
+     */
+    public static function provideData(): iterable
+    {
+        /** @var string[] $filePath */
+        foreach (self::yieldFilesFromDirectory(__DIR__ . '/Fixture') as $filePath) {
+            $filePath = \strval($filePath[0]);
+
+            yield $filePath => [
+                'filePath' => $filePath,
+            ];
+        }
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+}

--- a/tests/Rector/CompletePartialNamedArgumentsStrategy/Fixture/NoNamedArgsMethodCall.php.inc
+++ b/tests/Rector/CompletePartialNamedArgumentsStrategy/Fixture/NoNamedArgsMethodCall.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+class AnotherService
+{
+    public function process(string $name, int $count): void
+    {
+    }
+}
+
+$service = new AnotherService();
+$service->process('test', 100);

--- a/tests/Rector/CompletePartialNamedArgumentsStrategy/Fixture/PartiallyNamedMethodCall.php.inc
+++ b/tests/Rector/CompletePartialNamedArgumentsStrategy/Fixture/PartiallyNamedMethodCall.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+class SomeService
+{
+    public function process(string $name, int $count, bool $flag): void
+    {
+    }
+}
+
+$service = new SomeService();
+$service->process('test', count: 100, false);
+
+?>
+-----
+<?php
+
+class SomeService
+{
+    public function process(string $name, int $count, bool $flag): void
+    {
+    }
+}
+
+$service = new SomeService();
+$service->process(name: 'test', count: 100, flag: false);
+
+?>

--- a/tests/Rector/CompletePartialNamedArgumentsStrategy/Fixture/PartiallyNamedStaticCall.php.inc
+++ b/tests/Rector/CompletePartialNamedArgumentsStrategy/Fixture/PartiallyNamedStaticCall.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+class StaticService
+{
+    public static function create(string $type, int $priority): self
+    {
+        return new self();
+    }
+}
+
+StaticService::create('foo', priority: 10);
+
+?>
+-----
+<?php
+
+class StaticService
+{
+    public static function create(string $type, int $priority): self
+    {
+        return new self();
+    }
+}
+
+StaticService::create(type: 'foo', priority: 10);
+
+?>

--- a/tests/Rector/CompletePartialNamedArgumentsStrategy/config/configured_rule.php
+++ b/tests/Rector/CompletePartialNamedArgumentsStrategy/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+use EonX\EasyQuality\Rector\CompletePartialNamedArgumentsStrategy;
+use Rector\Config\RectorConfig;
+use SavinMikhail\AddNamedArgumentsRector\AddNamedArgumentsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AddNamedArgumentsRector::class, [
+        AddNamedArgumentsRector::STRATEGY => CompletePartialNamedArgumentsStrategy::class,
+    ]);
+};


### PR DESCRIPTION
We have a rule that If at least one argument is passed as a named one, then the rest arguments SHOULD be passed in the same way.

There is no rector that forces exactly that rule, but there is a rector `AddNamedArgumentsRector` that by default forces named arguments in all cases, and that behaviour can be adjusted by implementing a custom strategy.