### PR TITLE
feature/PBAO-1168-add-phpstan-rules-asserting-activity-log-subjects-a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 /.idea
 .phpunit.result.cache
 /.phpunit.cache/
-/.claude/
 
 # Igonre MacOS specific files
 .DS_Store
+
+# Ignore AI files
+**/.claude/
+**/.serena/

--- a/src/PhpStan/ActivityLogSubjectCoverageRule.php
+++ b/src/PhpStan/ActivityLogSubjectCoverageRule.php
@@ -1,0 +1,254 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\PhpStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use Throwable;
+
+/**
+ * Reports every subject configured in the given easy-activity config file that no test asserts.
+ *
+ * The rule needs its collector registered alongside it, and only reports on a full-scope analysis:
+ *
+ * ```neon
+ * services:
+ *     -
+ *         class: EonX\EasyQuality\PhpStan\AssertedActivityLogSubjectCollector
+ *         tags: [phpstan.collector]
+ *
+ *     -
+ *         class: EonX\EasyQuality\PhpStan\ActivityLogSubjectCoverageRule
+ *         tags: [phpstan.rules.rule]
+ *         arguments:
+ *             configFile: %currentWorkingDirectory%/config/packages/easy_activity.php
+ *             excludedSubjects:
+ *                 - App\Entity\Something
+ * ```
+ *
+ * @implements \PHPStan\Rules\Rule<\PHPStan\Node\CollectedDataNode>
+ */
+final readonly class ActivityLogSubjectCoverageRule implements Rule
+{
+    /**
+     * The config file calls this helper, which projects declare in `config/reference.php` and do not autoload.
+     */
+    private const string CONFIG_HELPER_CLASS = 'Symfony\Component\DependencyInjection\Loader\Configurator\App';
+
+    private const string EXCLUSION_NOT_NEEDED_IDENTIFIER = 'easyQuality.activityLogSubjectExclusionNotNeeded';
+
+    private const string MISCONFIGURED_IDENTIFIER = 'easyQuality.activityLogSubjectCoverageMisconfigured';
+
+    private const string NOT_ASSERTED_IDENTIFIER = 'easyQuality.activityLogSubjectNotAsserted';
+
+    /**
+     * @param string[] $excludedSubjects Subject classes that are knowingly not asserted
+     */
+    public function __construct(private string $configFile, private array $excludedSubjects = []) {}
+
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @param \PHPStan\Node\CollectedDataNode $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // Skip if it is not a full-scope check
+        if ($node->isOnlyFilesAnalysis()) {
+            return [];
+        }
+
+        // Requiring a missing file is a fatal error, and RuleErrorBuilder only anchors to existing files
+        if (\is_file($this->configFile) === false) {
+            return [
+                RuleErrorBuilder::message(
+                    \sprintf('The configured activity log config file %s does not exist.', $this->configFile),
+                )
+                    ->identifier(self::MISCONFIGURED_IDENTIFIER)
+                    ->build(),
+            ];
+        }
+
+        try {
+            $configuredSubjects = $this->getConfiguredSubjects();
+        } catch (Throwable $throwable) {
+            // A throwing config file would otherwise abort the analysis as an internal error
+            return [
+                $this->getError(
+                    \sprintf('The activity log config file cannot be loaded: %s.', $throwable->getMessage()),
+                    1,
+                    self::MISCONFIGURED_IDENTIFIER,
+                ),
+            ];
+        }
+
+        if ($configuredSubjects === []) {
+            return [
+                $this->getError(
+                    'No activity log subjects are configured, did the config structure change?',
+                    1,
+                    self::MISCONFIGURED_IDENTIFIER,
+                ),
+            ];
+        }
+
+        $assertedSubjects = [];
+
+        foreach ($node->get(AssertedActivityLogSubjectCollector::class) as $subjectsPerFile) {
+            foreach ($subjectsPerFile as $subjects) {
+                $assertedSubjects += \array_flip($subjects);
+            }
+        }
+
+        $subjectLines = $this->getSubjectLines();
+        $errors = [];
+
+        foreach ($configuredSubjects as $configuredSubject) {
+            if (isset($assertedSubjects[$configuredSubject])) {
+                continue;
+            }
+
+            if (\in_array($configuredSubject, $this->excludedSubjects, true)) {
+                continue;
+            }
+
+            $errors[] = $this->getError(
+                \sprintf(
+                    'No test asserts the activity log of the configured subject %s.'
+                    . ' Add an `%s()` assertion for it.',
+                    $configuredSubject,
+                    AssertedActivityLogSubjectCollector::METHOD_NAME,
+                ),
+                $subjectLines[$configuredSubject] ?? 1,
+                self::NOT_ASSERTED_IDENTIFIER,
+            );
+        }
+
+        return \array_merge(
+            $errors,
+            $this->getStaleExclusionErrors($configuredSubjects, $assertedSubjects, $subjectLines),
+        );
+    }
+
+    /**
+     * The helper lives in `config/reference.php`, at an unknown depth above the config file: an environment
+     * config, such as `config/packages/test/x.php`, sits one level deeper than a regular one.
+     */
+    private static function requireReferenceFile(string $configFile): void
+    {
+        $directory = \dirname($configFile);
+
+        while ($directory !== \dirname($directory)) {
+            $referenceFile = $directory . '/reference.php';
+
+            if (\is_file($referenceFile)) {
+                require_once $referenceFile;
+
+                return;
+            }
+
+            $directory = \dirname($directory);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getConfiguredSubjects(): array
+    {
+        if (\class_exists(self::CONFIG_HELPER_CLASS) === false) {
+            self::requireReferenceFile($this->configFile);
+        }
+
+        /** @var array{easy_activity?: array{subjects?: array<string, array<string, string|string[]>>}} $config */
+        $config = require $this->configFile;
+
+        return \array_keys($config['easy_activity']['subjects'] ?? []);
+    }
+
+    private function getError(string $message, int $line, string $identifier): RuleError
+    {
+        return RuleErrorBuilder::message($message)
+            ->identifier($identifier)
+            ->file($this->configFile)
+            ->line($line)
+            ->build();
+    }
+
+    /**
+     * @param string[] $configuredSubjects
+     * @param array<string, int> $assertedSubjects
+     * @param array<string, int> $subjectLines
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    private function getStaleExclusionErrors(
+        array $configuredSubjects,
+        array $assertedSubjects,
+        array $subjectLines,
+    ): array {
+        $errors = [];
+
+        foreach ($this->excludedSubjects as $excludedSubject) {
+            $isConfigured = \in_array($excludedSubject, $configuredSubjects, true);
+
+            if ($isConfigured && isset($assertedSubjects[$excludedSubject]) === false) {
+                continue;
+            }
+
+            $errors[] = $this->getError(
+                \sprintf(
+                    'The excluded subject %s is %s. Remove it from the excluded subjects.',
+                    $excludedSubject,
+                    $isConfigured ? 'asserted by a test' : 'not a configured subject',
+                ),
+                $subjectLines[$excludedSubject] ?? 1,
+                self::EXCLUSION_NOT_NEEDED_IDENTIFIER,
+            );
+        }
+
+        return $errors;
+    }
+
+    /**
+     * The config declares its subjects by short name, so the class names are resolved from the imports.
+     *
+     * @return array<string, int> Subject class => line of the `X::class` declaring it
+     */
+    private function getSubjectLines(): array
+    {
+        $statements = new ParserFactory()->createForNewestSupportedVersion()
+            ->parse((string)\file_get_contents($this->configFile)) ?? [];
+        $statements = new NodeTraverser(new NameResolver())->traverse($statements);
+        $lines = [];
+
+        foreach (new NodeFinder()->findInstanceOf($statements, ClassConstFetch::class) as $classConstFetch) {
+            if ($classConstFetch->class instanceof Name
+                && $classConstFetch->name instanceof Identifier
+                && $classConstFetch->name->toLowerString() === 'class') {
+                // The first `X::class` of a subject wins
+                $lines[$classConstFetch->class->toString()] ??= $classConstFetch->getStartLine();
+            }
+        }
+
+        return $lines;
+    }
+}

--- a/src/PhpStan/AssertedActivityLogSubjectCollector.php
+++ b/src/PhpStan/AssertedActivityLogSubjectCollector.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\PhpStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Collects the subjects asserted through `assertActivityLog()`, see ActivityLogSubjectCoverageRule.
+ *
+ * @implements \PHPStan\Collectors\Collector<\PhpParser\Node\Expr\MethodCall, string[]>
+ */
+final readonly class AssertedActivityLogSubjectCollector implements Collector
+{
+    public const string METHOD_NAME = 'assertActivityLog';
+
+    private const string SUBJECT_ARGUMENT_NAME = 'subject';
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\MethodCall $node
+     *
+     * @return string[]|null
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if ($node->name instanceof Identifier === false || $node->name->toString() !== self::METHOD_NAME) {
+            return null;
+        }
+
+        $subjectArgument = self::getSubjectArgument($node->getArgs());
+
+        if ($subjectArgument === null) {
+            return null;
+        }
+
+        // A nullable finder result resolves to no class name until `null` is removed
+        $subjectType = TypeCombinator::removeNull($scope->getType($subjectArgument->value));
+        $subjectClasses = $subjectType->getObjectClassNames();
+
+        return $subjectClasses === [] ? null : $subjectClasses;
+    }
+
+    /**
+     * The subject must be passed by name, positional calls are not supported.
+     *
+     * @param \PhpParser\Node\Arg[] $arguments
+     */
+    private static function getSubjectArgument(array $arguments): ?Arg
+    {
+        foreach ($arguments as $argument) {
+            if ($argument->name?->toString() === self::SUBJECT_ARGUMENT_NAME) {
+                return $argument;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/PhpStan/AssertedWebhookEventCollector.php
+++ b/src/PhpStan/AssertedWebhookEventCollector.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\PhpStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+
+/**
+ * Collects the `'event' => '...'` criteria asserted against the webhook entity, see WebhookEventCoverageRule.
+ *
+ * Both shapes are collected: `findOneEntity(Webhook::class, ['event' => 'merchant:update'])` and
+ * `assertEntity(Webhook::class)->toBeInDb(['event' => 'merchant:update'])`. The criteria must belong to a
+ * positive assertion, the entity class may sit anywhere in the chain.
+ *
+ * @implements \PHPStan\Collectors\Collector<\PhpParser\Node\Expr\MethodCall, string>
+ */
+final readonly class AssertedWebhookEventCollector implements Collector
+{
+    private const string EVENT_KEY = 'event';
+
+    /**
+     * @var string[]
+     */
+    private const array POSITIVE_ASSERTIONS = ['findOneEntity', 'toBeInDb'];
+
+    /**
+     * @param string $entityClass The asserted webhook entity, such as `App\Entity\Webhook`
+     */
+    public function __construct(private string $entityClass) {}
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\MethodCall $node
+     */
+    public function processNode(Node $node, Scope $scope): ?string
+    {
+        if (self::isPositiveAssertion($node) === false) {
+            return null;
+        }
+
+        $event = self::getAssertedEvent($node->getArgs());
+
+        if ($event === null) {
+            return null;
+        }
+
+        // The entity class may sit in an earlier call of the chain, such as `assertEntity(Webhook::class)`
+        return $this->assertsEntityClass(self::getChainArguments($node), $scope) ? $event : null;
+    }
+
+    /**
+     * @param \PhpParser\Node\Arg[] $arguments
+     */
+    private static function getAssertedEvent(array $arguments): ?string
+    {
+        foreach ($arguments as $argument) {
+            if ($argument->value instanceof Array_ === false) {
+                continue;
+            }
+
+            foreach ($argument->value->items as $item) {
+                if ($item->key instanceof String_
+                    && $item->key->value === self::EVENT_KEY
+                    && $item->value instanceof String_) {
+                    return $item->value->value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return \PhpParser\Node\Arg[]
+     */
+    private static function getChainArguments(MethodCall $node): array
+    {
+        $arguments = [];
+
+        for ($call = $node; $call instanceof MethodCall; $call = $call->var) {
+            $arguments = [...$arguments, ...$call->getArgs()];
+        }
+
+        return $arguments;
+    }
+
+    private static function isPositiveAssertion(MethodCall $call): bool
+    {
+        return $call->name instanceof Identifier
+            && \in_array($call->name->toString(), self::POSITIVE_ASSERTIONS, true);
+    }
+
+    /**
+     * @param \PhpParser\Node\Arg[] $arguments
+     */
+    private function assertsEntityClass(array $arguments, Scope $scope): bool
+    {
+        $entityClass = \ltrim($this->entityClass, '\\');
+
+        foreach ($arguments as $argument) {
+            // A `Webhook::class` argument resolves to one constant string, the class name
+            foreach ($scope->getType($argument->value)->getConstantStrings() as $constantString) {
+                if (\ltrim($constantString->getValue(), '\\') === $entityClass) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/PhpStan/WebhookEventCoverageRule.php
+++ b/src/PhpStan/WebhookEventCoverageRule.php
@@ -1,0 +1,181 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\PhpStan;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Reports every case of the given webhook event enum that is never asserted in the tests.
+ *
+ * The rule needs its collector registered alongside it, and only reports on a full-scope analysis:
+ *
+ * ```neon
+ * services:
+ *     -
+ *         class: EonX\EasyQuality\PhpStan\AssertedWebhookEventCollector
+ *         tags: [phpstan.collector]
+ *
+ *     -
+ *         class: EonX\EasyQuality\PhpStan\WebhookEventCoverageRule
+ *         tags: [phpstan.rules.rule]
+ *         arguments:
+ *             enumClass: App\Webhook\Enum\WebhookEvent
+ *             excludedEvents:
+ *                 - merchant:update
+ * ```
+ *
+ * @implements \PHPStan\Rules\Rule<\PHPStan\Node\CollectedDataNode>
+ */
+final readonly class WebhookEventCoverageRule implements Rule
+{
+    private const string EXCLUSION_NOT_NEEDED_IDENTIFIER = 'easyQuality.webhookEventExclusionNotNeeded';
+
+    private const string MISCONFIGURED_IDENTIFIER = 'easyQuality.webhookEventCoverageMisconfigured';
+
+    private const string NOT_ASSERTED_IDENTIFIER = 'easyQuality.webhookEventNotAsserted';
+
+    /**
+     * @param string[] $excludedEvents Event values, such as `merchant:update`, that are knowingly not asserted
+     */
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private string $enumClass,
+        private array $excludedEvents = [],
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @param \PHPStan\Node\CollectedDataNode $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // Skip if it is not a full-scope check
+        if ($node->isOnlyFilesAnalysis()) {
+            return [];
+        }
+
+        // A missing class or a non-enum throws on purpose: a misconfigured rule must not report nothing
+        $enum = $this->reflectionProvider->getClass($this->enumClass);
+        $enumFile = (string)$enum->getFileName();
+        $configuredEvents = [];
+
+        foreach ($enum->getEnumCases() as $case) {
+            // A backed case has exactly one constant string
+            $event = ($case->getBackingValueType()?->getConstantStrings()[0] ?? null)?->getValue();
+
+            if ($event !== null) {
+                $configuredEvents[$event] = $case->getName();
+            }
+        }
+
+        // Without backed cases there are no events, so every event would look asserted
+        if ($configuredEvents === []) {
+            return [
+                self::getError(
+                    \sprintf('No backed events are declared in %s, did the enum change?', $this->enumClass),
+                    1,
+                    $enumFile,
+                    self::MISCONFIGURED_IDENTIFIER,
+                ),
+            ];
+        }
+
+        $assertedEvents = [];
+
+        foreach ($node->get(AssertedWebhookEventCollector::class) as $eventsPerFile) {
+            $assertedEvents += \array_flip($eventsPerFile);
+        }
+
+        $errors = [];
+
+        foreach ($configuredEvents as $event => $caseName) {
+            if (isset($assertedEvents[$event]) || \in_array($event, $this->excludedEvents, true)) {
+                continue;
+            }
+
+            $errors[] = self::getError(
+                \sprintf(
+                    "No test asserts the webhook event %s. Assert the webhook entity with `'event' => '%s'`"
+                    . ' in a test.',
+                    $caseName,
+                    $event,
+                ),
+                self::getEventLine($event, $enumFile),
+                $enumFile,
+                self::NOT_ASSERTED_IDENTIFIER,
+            );
+        }
+
+        return \array_merge($errors, $this->getStaleExclusionErrors($configuredEvents, $assertedEvents, $enumFile));
+    }
+
+    private static function getError(
+        string $message,
+        int $line,
+        string $enumFile,
+        string $identifier,
+    ): RuleError {
+        return RuleErrorBuilder::message($message)
+            ->identifier($identifier)
+            ->file($enumFile)
+            ->line($line)
+            ->build();
+    }
+
+    private static function getEventLine(string $event, string $enumFile): int
+    {
+        $pattern = \sprintf("/= '%s';/", \preg_quote($event, '/'));
+        $matchedLines = \preg_grep($pattern, (array)\file($enumFile));
+
+        // The first matching line wins, line 1 when the event is not in the enum at all
+        return (int)\array_key_first($matchedLines === false ? [] : $matchedLines) + 1;
+    }
+
+    /**
+     * An exclusion must be dropped once its event is asserted or gone, otherwise the list never shrinks.
+     *
+     * @param array<string, string> $configuredEvents
+     * @param array<string, int> $assertedEvents
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    private function getStaleExclusionErrors(array $configuredEvents, array $assertedEvents, string $enumFile): array
+    {
+        $errors = [];
+
+        foreach ($this->excludedEvents as $excludedEvent) {
+            $isConfigured = isset($configuredEvents[$excludedEvent]);
+
+            if ($isConfigured && isset($assertedEvents[$excludedEvent]) === false) {
+                continue;
+            }
+
+            $errors[] = self::getError(
+                \sprintf(
+                    'The excluded webhook event %s is %s. Remove it from the excluded events.',
+                    $excludedEvent,
+                    $isConfigured ? 'asserted by a test' : 'not a case of the event enum',
+                ),
+                self::getEventLine($excludedEvent, $enumFile),
+                $enumFile,
+                self::EXCLUSION_NOT_NEEDED_IDENTIFIER,
+            );
+        }
+
+        return $errors;
+    }
+}

--- a/tests/PhpStan/ActivityLogSubjectCoverageRule/ActivityLogSubjectCoverageRuleTest.php
+++ b/tests/PhpStan/ActivityLogSubjectCoverageRule/ActivityLogSubjectCoverageRuleTest.php
@@ -1,0 +1,148 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule;
+
+use EonX\EasyQuality\PhpStan\ActivityLogSubjectCoverageRule;
+use EonX\EasyQuality\PhpStan\AssertedActivityLogSubjectCollector;
+use EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub\AssertedSubjectStub;
+use EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub\NotAssertedSubjectStub;
+use EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub\SubNotAssertedSubjectStub;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<\EonX\EasyQuality\PhpStan\ActivityLogSubjectCoverageRule>
+ */
+final class ActivityLogSubjectCoverageRuleTest extends RuleTestCase
+{
+    private const string BROKEN_CONFIG_FILE = __DIR__ . '/Fixture/config/packages/broken_activity.php';
+
+    private const string COLLIDING_CONFIG_FILE = __DIR__ . '/Fixture/config/packages/colliding_activity.php';
+
+    private const string CONFIG_FILE = __DIR__ . '/Fixture/config/packages/easy_activity.php';
+
+    private const string FIXTURE = __DIR__ . '/Fixture/AssertsOneSubject.php';
+
+    private const string MISSING_CONFIG_FILE = __DIR__ . '/Fixture/config/packages/does_not_exist.php';
+
+    private string $configFile = self::CONFIG_FILE;
+
+    /**
+     * @var string[]
+     */
+    private array $excludedSubjects = [];
+
+    /**
+     * @see testRule
+     */
+    public static function provideData(): iterable
+    {
+        yield 'reports the configured subject that no test asserts' => [
+            [],
+            [
+                [self::getNotAssertedError(NotAssertedSubjectStub::class), 13],
+            ],
+        ];
+
+        yield 'reports the excluded subject that is asserted or not configured' => [
+            [AssertedSubjectStub::class, 'App\\Unknown\\Subject'],
+            [
+                [
+                    'The excluded subject App\\Unknown\\Subject is not a configured subject.'
+                    . ' Remove it from the excluded subjects.',
+                    1,
+                ],
+                [
+                    'The excluded subject ' . AssertedSubjectStub::class . ' is asserted by a test.'
+                    . ' Remove it from the excluded subjects.',
+                    10,
+                ],
+                [self::getNotAssertedError(NotAssertedSubjectStub::class), 13],
+            ],
+        ];
+
+        yield 'reports nothing when the not asserted subject is excluded' => [
+            [NotAssertedSubjectStub::class],
+            [],
+        ];
+    }
+
+    /**
+     * @param string[] $excludedSubjects
+     * @param list<array{0: string, 1: int, 2?: string}> $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(array $excludedSubjects, array $expectedErrorMessagesWithLines): void
+    {
+        $this->excludedSubjects = $excludedSubjects;
+
+        $this->analyse([self::FIXTURE], $expectedErrorMessagesWithLines);
+    }
+
+    /**
+     * A subject whose short name is a suffix of another one must still be anchored to its own line.
+     */
+    public function testRuleAnchorsSubjectsWithCollidingShortNames(): void
+    {
+        $this->configFile = self::COLLIDING_CONFIG_FILE;
+
+        $this->analyse([self::FIXTURE], [
+            [self::getNotAssertedError(SubNotAssertedSubjectStub::class), 11],
+            [self::getNotAssertedError(NotAssertedSubjectStub::class), 14],
+        ]);
+    }
+
+    /**
+     * A throwing config file would otherwise abort the analysis as an internal error.
+     */
+    public function testRuleReportsConfigFileThatCannotBeLoaded(): void
+    {
+        $this->configFile = self::BROKEN_CONFIG_FILE;
+
+        $this->analyse([self::FIXTURE], [
+            [
+                'The activity log config file cannot be loaded: Class "MissingConfigHelper" not found.',
+                1,
+            ],
+        ]);
+    }
+
+    /**
+     * The error is not anchored to a file, hence line -1.
+     */
+    public function testRuleReportsMissingConfigFile(): void
+    {
+        $this->configFile = self::MISSING_CONFIG_FILE;
+
+        $this->analyse([self::FIXTURE], [
+            [
+                \sprintf('The configured activity log config file %s does not exist.', self::MISSING_CONFIG_FILE),
+                -1,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<\PHPStan\Collectors\Collector<\PhpParser\Node, string[]>>
+     */
+    protected function getCollectors(): array
+    {
+        return [new AssertedActivityLogSubjectCollector()];
+    }
+
+    protected function getRule(): Rule
+    {
+        return new ActivityLogSubjectCoverageRule($this->configFile, $this->excludedSubjects);
+    }
+
+    private static function getNotAssertedError(string $subject): string
+    {
+        return \sprintf(
+            'No test asserts the activity log of the configured subject %s.'
+            . ' Add an `assertActivityLog()` assertion for it.',
+            $subject,
+        );
+    }
+}

--- a/tests/PhpStan/ActivityLogSubjectCoverageRule/Fixture/AssertsOneSubject.php
+++ b/tests/PhpStan/ActivityLogSubjectCoverageRule/Fixture/AssertsOneSubject.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Fixture;
+
+use EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub\ActivityLogAssertionStub;
+use EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub\AssertedSubjectStub;
+
+final class AssertsOneSubject
+{
+    public function assertSubject(): void
+    {
+        $assertion = new ActivityLogAssertionStub();
+
+        $assertion->assertActivityLog(action: 'create', subject: new AssertedSubjectStub());
+    }
+}

--- a/tests/PhpStan/ActivityLogSubjectCoverageRule/Fixture/config/packages/broken_activity.php
+++ b/tests/PhpStan/ActivityLogSubjectCoverageRule/Fixture/config/packages/broken_activity.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+// Stands in for a config file calling a helper that is neither autoloaded nor declared in a reference file
+return MissingConfigHelper::config([
+    'easy_activity' => [
+        'subjects' => [],
+    ],
+]);

--- a/tests/PhpStan/ActivityLogSubjectCoverageRule/Fixture/config/packages/colliding_activity.php
+++ b/tests/PhpStan/ActivityLogSubjectCoverageRule/Fixture/config/packages/colliding_activity.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub\NotAssertedSubjectStub;
+use EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub\SubNotAssertedSubjectStub;
+
+return [
+    'easy_activity' => [
+        'subjects' => [
+            // The short name of the subject below is a suffix of this one
+            SubNotAssertedSubjectStub::class => [
+                'type' => 'SubNotAssertedSubjectStub',
+            ],
+            NotAssertedSubjectStub::class => [
+                'type' => 'NotAssertedSubjectStub',
+            ],
+        ],
+    ],
+];

--- a/tests/PhpStan/ActivityLogSubjectCoverageRule/Fixture/config/packages/easy_activity.php
+++ b/tests/PhpStan/ActivityLogSubjectCoverageRule/Fixture/config/packages/easy_activity.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+use EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub\AssertedSubjectStub;
+use EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub\NotAssertedSubjectStub;
+
+return [
+    'easy_activity' => [
+        'subjects' => [
+            AssertedSubjectStub::class => [
+                'type' => 'AssertedSubjectStub',
+            ],
+            NotAssertedSubjectStub::class => [
+                'type' => 'NotAssertedSubjectStub',
+            ],
+        ],
+    ],
+];

--- a/tests/PhpStan/ActivityLogSubjectCoverageRule/Stub/ActivityLogAssertionStub.php
+++ b/tests/PhpStan/ActivityLogSubjectCoverageRule/Stub/ActivityLogAssertionStub.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub;
+
+final class ActivityLogAssertionStub
+{
+    public function assertActivityLog(string $action, object $subject): void
+    {
+        // Intentionally empty, the rule only looks at the call site
+    }
+}

--- a/tests/PhpStan/ActivityLogSubjectCoverageRule/Stub/AssertedSubjectStub.php
+++ b/tests/PhpStan/ActivityLogSubjectCoverageRule/Stub/AssertedSubjectStub.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub;
+
+final class AssertedSubjectStub {}

--- a/tests/PhpStan/ActivityLogSubjectCoverageRule/Stub/NotAssertedSubjectStub.php
+++ b/tests/PhpStan/ActivityLogSubjectCoverageRule/Stub/NotAssertedSubjectStub.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub;
+
+final class NotAssertedSubjectStub {}

--- a/tests/PhpStan/ActivityLogSubjectCoverageRule/Stub/SubNotAssertedSubjectStub.php
+++ b/tests/PhpStan/ActivityLogSubjectCoverageRule/Stub/SubNotAssertedSubjectStub.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\ActivityLogSubjectCoverageRule\Stub;
+
+final class SubNotAssertedSubjectStub {}

--- a/tests/PhpStan/WebhookEventCoverageRule/Fixture/AssertsSomeEvents.php
+++ b/tests/PhpStan/WebhookEventCoverageRule/Fixture/AssertsSomeEvents.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Fixture;
+
+use EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Stub\EntityExpectationStub;
+use EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Stub\WebhookStub;
+
+final class AssertsSomeEvents
+{
+    public function testWebhooks(): void
+    {
+        $this->findOneEntity(WebhookStub::class, [
+            'event' => 'asserted:same_call',
+        ]);
+
+        $this->assertEntity(WebhookStub::class)
+            ->toBeInDb([
+                'event' => 'asserted:chain',
+            ]);
+
+        // Asserting the absence of a webhook does not cover its event
+        $this->assertEntity(WebhookStub::class)
+            ->toNotBeInDb([
+                'event' => 'not_asserted:negatively',
+            ]);
+
+        // The same criteria key of another entity does not cover the event either
+        $this->findOneEntity(\stdClass::class, [
+            'event' => 'not_asserted:other_entity',
+        ]);
+    }
+
+    private function assertEntity(string $entityClass): EntityExpectationStub
+    {
+        return new EntityExpectationStub();
+    }
+
+    /**
+     * @param array<string, string> $criteria
+     */
+    private function findOneEntity(string $entityClass, array $criteria): void
+    {
+        // Stands in for the entity finder of the project under analysis
+    }
+}

--- a/tests/PhpStan/WebhookEventCoverageRule/Stub/EntityExpectationStub.php
+++ b/tests/PhpStan/WebhookEventCoverageRule/Stub/EntityExpectationStub.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Stub;
+
+/**
+ * Stands in for the fluent entity assertion of the project under analysis.
+ */
+final class EntityExpectationStub
+{
+    /**
+     * @param array<string, string> $criteria
+     */
+    public function toBeInDb(array $criteria): self
+    {
+        return $this;
+    }
+
+    /**
+     * @param array<string, string> $criteria
+     */
+    public function toNotBeInDb(array $criteria): self
+    {
+        return $this;
+    }
+}

--- a/tests/PhpStan/WebhookEventCoverageRule/Stub/UnbackedWebhookEventStub.php
+++ b/tests/PhpStan/WebhookEventCoverageRule/Stub/UnbackedWebhookEventStub.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Stub;
+
+/**
+ * Stands in for an event enum that lost its backing type.
+ */
+enum UnbackedWebhookEventStub
+{
+    case AssertedInChain;
+}

--- a/tests/PhpStan/WebhookEventCoverageRule/Stub/WebhookEventStub.php
+++ b/tests/PhpStan/WebhookEventCoverageRule/Stub/WebhookEventStub.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Stub;
+
+enum WebhookEventStub: string
+{
+    case AssertedInChain = 'asserted:chain';
+
+    case AssertedInSameCall = 'asserted:same_call';
+
+    case NotAsserted = 'not_asserted:plain';
+
+    case NotAssertedForOtherEntity = 'not_asserted:other_entity';
+
+    case NotAssertedNegatively = 'not_asserted:negatively';
+}

--- a/tests/PhpStan/WebhookEventCoverageRule/Stub/WebhookStub.php
+++ b/tests/PhpStan/WebhookEventCoverageRule/Stub/WebhookStub.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Stub;
+
+final class WebhookStub {}

--- a/tests/PhpStan/WebhookEventCoverageRule/WebhookEventCoverageRuleTest.php
+++ b/tests/PhpStan/WebhookEventCoverageRule/WebhookEventCoverageRuleTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule;
+
+use EonX\EasyQuality\PhpStan\AssertedWebhookEventCollector;
+use EonX\EasyQuality\PhpStan\WebhookEventCoverageRule;
+use EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Stub\UnbackedWebhookEventStub;
+use EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Stub\WebhookEventStub;
+use EonX\EasyQuality\Tests\PhpStan\WebhookEventCoverageRule\Stub\WebhookStub;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<\EonX\EasyQuality\PhpStan\WebhookEventCoverageRule>
+ */
+final class WebhookEventCoverageRuleTest extends RuleTestCase
+{
+    private const string FIXTURE = __DIR__ . '/Fixture/AssertsSomeEvents.php';
+
+    /**
+     * The events the fixture leaves uncovered, the enum stub declares them on lines 12, 14 and 16.
+     *
+     * @var string[]
+     */
+    private const array NOT_ASSERTED_EVENTS = [
+        'not_asserted:plain',
+        'not_asserted:other_entity',
+        'not_asserted:negatively',
+    ];
+
+    private string $enumClass = WebhookEventStub::class;
+
+    /**
+     * @var string[]
+     */
+    private array $excludedEvents = [];
+
+    /**
+     * @see testRule
+     */
+    public static function provideData(): iterable
+    {
+        yield 'reports the webhook events that no test asserts' => [
+            [],
+            [
+                [self::getNotAssertedError('NotAsserted', 'not_asserted:plain'), 12],
+                [self::getNotAssertedError('NotAssertedForOtherEntity', 'not_asserted:other_entity'), 14],
+                [self::getNotAssertedError('NotAssertedNegatively', 'not_asserted:negatively'), 16],
+            ],
+        ];
+
+        yield 'reports the excluded event that is asserted or not a case of the enum' => [
+            [
+                WebhookEventStub::AssertedInChain->value,
+                'unknown:event',
+                ...self::NOT_ASSERTED_EVENTS,
+            ],
+            [
+                [
+                    'The excluded webhook event unknown:event is not a case of the event enum.'
+                    . ' Remove it from the excluded events.',
+                    1,
+                ],
+                [
+                    'The excluded webhook event asserted:chain is asserted by a test.'
+                    . ' Remove it from the excluded events.',
+                    8,
+                ],
+            ],
+        ];
+
+        yield 'reports nothing when every not asserted event is excluded' => [
+            self::NOT_ASSERTED_EVENTS,
+            [],
+        ];
+    }
+
+    /**
+     * @param string[] $excludedEvents
+     * @param list<array{0: string, 1: int, 2?: string}> $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(array $excludedEvents, array $expectedErrorMessagesWithLines): void
+    {
+        $this->excludedEvents = $excludedEvents;
+
+        $this->analyse([self::FIXTURE], $expectedErrorMessagesWithLines);
+    }
+
+    /**
+     * An enum without backed cases would otherwise report nothing at all.
+     */
+    public function testRuleReportsEnumWithoutBackedEvents(): void
+    {
+        $this->enumClass = UnbackedWebhookEventStub::class;
+
+        $this->analyse([self::FIXTURE], [
+            [
+                \sprintf('No backed events are declared in %s, did the enum change?', UnbackedWebhookEventStub::class),
+                1,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<\PHPStan\Collectors\Collector<\PhpParser\Node, string>>
+     */
+    protected function getCollectors(): array
+    {
+        return [new AssertedWebhookEventCollector(WebhookStub::class)];
+    }
+
+    protected function getRule(): Rule
+    {
+        return new WebhookEventCoverageRule(
+            $this->createReflectionProvider(),
+            $this->enumClass,
+            $this->excludedEvents,
+        );
+    }
+
+    private static function getNotAssertedError(string $case, string $event): string
+    {
+        return \sprintf(
+            "No test asserts the webhook event %s. Assert the webhook entity with `'event' => '%s'` in a test.",
+            $case,
+            $event,
+        );
+    }
+}


### PR DESCRIPTION
Both rules report configured entries that no test asserts, anchored to the line of the config or enum that declares them:

- ActivityLogSubjectCoverageRule reads the easy-activity config and pairs it with the subjects collected from `assertActivityLog(subject: ...)` calls.
- WebhookEventCoverageRule reads a backed event enum and pairs it with the `'event' => '...'` criteria asserted against the webhook entity, either as `findOneEntity(Webhook::class, [...])` or as `assertEntity(Webhook::class)->toBeInDb([...])`. 

Both rules take a list of knowingly unasserted entries and report an entry of that list once it is asserted or gone, so the list cannot silently grow stale.